### PR TITLE
Added Godep dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _testmain.go
 
 # PTMerge binary
 ptmerge
+
+# Glide dependency management
+vendor/**

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+language: go
+go:
+- 1.7
+install:
+- go get github.com/Masterminds/glide
+- glide install
+script: go test $(glide novendor)
+services:
+- mongodb

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,43 @@
+hash: 074cdd275860b38e3e1d6a949bcffce84a2281adb615b39b97bf89336b353afc
+updated: 2017-01-23T12:39:14.988866254-05:00
+imports:
+- name: github.com/gin-gonic/gin
+  version: e2212d40c62a98b388a5eb48ecbdcf88534688ba
+  subpackages:
+  - binding
+  - render
+- name: github.com/golang/protobuf
+  version: 2402d76f3d41f928c7902a765dfc872356dd3aad
+  subpackages:
+  - proto
+- name: github.com/manucorporat/sse
+  version: ee05b128a739a0fb76c7ebd3ae4810c1de808d6d
+- name: github.com/mattn/go-isatty
+  version: 30a891c33c7cde7b02a981314b4228ec99380cca
+- name: golang.org/x/net
+  version: f315505cf3349909cdf013ea56690da34e96a451
+  subpackages:
+  - context
+- name: golang.org/x/sys
+  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
+  subpackages:
+  - unix
+- name: gopkg.in/go-playground/validator.v8
+  version: c193cecd124b5cc722d7ee5538e945bdb3348435
+- name: gopkg.in/yaml.v2
+  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  subpackages:
+  - assert
+  - require
+  - suite

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,9 @@
+package: github.com/mitre/ptmerge
+import:
+- package: github.com/gin-gonic/gin
+  version: v1.1.4
+testImport:
+- package: github.com/stretchr/testify
+  version: v1.1.4
+  subpackages:
+  - suite


### PR DESCRIPTION
Setup Godep to manage our project's dependencies. Currently the intervention-engine FHIR models are not listed as a dependency. We'll need to add those when we merge our first branch using those models.