### PR TITLE
MongoDB Connection and Command Line Flags

### DIFF
--- a/ptmerge.go
+++ b/ptmerge.go
@@ -1,8 +1,19 @@
 package main
 
-import "github.com/mitre/ptmerge/server"
+import (
+	"flag"
+
+	"github.com/mitre/ptmerge/server"
+)
 
 func main() {
-	server := server.NewServer()
+	// command line flags
+	fhirhost := flag.String("fhirhost", "http://localhost:3001", "The FHIR server used to host the ptmerge service")
+	dbhost := flag.String("db", "localhost:27017", "The Mongo database used to host the ptmerge service")
+	dbname := flag.String("dbname", "ptmerge", "The name of the Mongo database")
+	debug := flag.Bool("debug", false, "Run the ptmerge service in debug mode (more verbose output)")
+	flag.Parse()
+
+	server := server.NewServer(*fhirhost, *dbhost, *dbname, *debug)
 	server.Run()
 }

--- a/server/server.go
+++ b/server/server.go
@@ -9,7 +9,7 @@ import (
 	mgo "gopkg.in/mgo.v2"
 )
 
-// PTMergeServer contains the router and database connection needed to server the
+// PTMergeServer contains the router and database connection needed to serve the
 // patient merging service.
 type PTMergeServer struct {
 	Engine       *gin.Engine

--- a/server/server.go
+++ b/server/server.go
@@ -1,22 +1,69 @@
 package server
 
-import "github.com/gin-gonic/gin"
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/gin-gonic/gin"
+	mgo "gopkg.in/mgo.v2"
+)
 
 // PTMergeServer contains the router and database connection needed to server the
 // patient merging service.
 type PTMergeServer struct {
-	Engine *gin.Engine
+	Engine       *gin.Engine
+	FHIRHost     string
+	DatabaseHost string
+	DatabaseName string
+	Database     *mgo.Database
 }
 
 // NewServer returns a newly initialized PTMergeServer.
-func NewServer() *PTMergeServer {
+func NewServer(fhirhost, dbhost, dbname string, debug bool) *PTMergeServer {
+	if debug {
+		gin.SetMode(gin.DebugMode)
+	} else {
+		gin.SetMode(gin.ReleaseMode)
+	}
+
 	return &PTMergeServer{
-		Engine: gin.Default(),
+		Engine:       gin.Default(), // includes the default logging and recovery middleware
+		FHIRHost:     fhirhost,
+		DatabaseHost: dbhost,
+		DatabaseName: dbname,
+		Database:     nil,
 	}
 }
 
-// Run sets up the routing and starts the server.
+// Run sets up the routing, database, and FHIR server connections, then starts the server.
 func (p *PTMergeServer) Run() {
+	var err error
+	log.Println("Starting ptmerge service...")
+
+	// setup the host database connection
+	log.Println("Connecting to mongodb...")
+	session, err := mgo.Dial(p.DatabaseHost) // has a 1-minute timeout
+	if err != nil {
+		log.Printf("Failed to connect to mongodb at %s\n", p.DatabaseHost)
+		os.Exit(1)
+	}
+	log.Printf("Connected to mongodb at %s\n", p.DatabaseHost)
+
+	p.Database = session.DB(p.DatabaseName)
+
+	// ping the host FHIR server to make sure it's running
+	log.Println("Connecting to host FHIR server...")
+	_, err = http.Get(p.FHIRHost + "/metadata")
+	if err != nil {
+		log.Printf("Host FHIR server unavailable. Could not reach %s\n", p.FHIRHost)
+		os.Exit(1)
+	}
+	log.Printf("Connected to host FHIR server at %s\n", p.FHIRHost)
+
+	// register ptmerge service routes
 	RegisterRoutes(p.Engine)
+	log.Println("Started ptmerge service!")
+
 	p.Engine.Run(":5000")
 }


### PR DESCRIPTION
Added a mongodb connection that ptmerge can use to store/track the state of a merge. Also added checks that ptmerge can connect to the FHIR server that will be used to store the merged Bundle and OperationOutcomes. You can see what CLI flags are available using the `--help` flag:

```
Usage of ptmerge:
  -db string
    	The Mongo database used to host the ptmerge service (default "localhost:27017")
  -dbname string
    	The name of the Mongo database (default "ptmerge")
  -debug
    	Run the service in debug mode (more verbose output)
  -fhirhost string
    	The FHIR server used to host the ptmerge service (default "http://localhost:3001")
```