### PR TITLE
MergeController and test fixtures

### DIFF
--- a/fixtures/clint_abbot_bundle.json
+++ b/fixtures/clint_abbot_bundle.json
@@ -1,0 +1,207 @@
+{
+  "resourceType": "Bundle",
+  "id": "bundle-transaction",
+  "type": "transaction",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f2a",
+      "resource": {
+      	"resourceType": "Patient",
+      	"id": "61ebe359-bfdc-4613-8bf2-c5e300945f2a",
+      	"name": [{
+      		"family": ["Abbott"],
+      		"given": ["Clint"]
+      	}],
+      	"gender": "male",
+      	"birthDate": "1950-09-02"
+      },
+      "request": {
+        "method": "POST",
+        "url": "Patient"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f2b",
+      "resource": {
+      	"resourceType": "Encounter",
+      	"id": "61ebe359-bfdc-4613-8bf2-c5e300945f2b",
+      	"status": "finished",
+      	"type": [{
+      		"coding": [{
+      			"system": "http://www.ama-assn.org/go/cpt",
+      			"code": "99201"
+      		}],
+      		"text": "Office Visit"
+      	}],
+      	"patient": {
+      		"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f2a"
+      	},
+      	"period": {
+      		"start": "2012-09-20T08:00:00-05:00"
+      	}
+      },
+      "request": {
+        "method": "POST",
+        "url": "Encounter"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f2c",
+      "resource": {
+      	"resourceType": "Encounter",
+      	"id": "61ebe359-bfdc-4613-8bf2-c5e300945f2c",
+      	"status": "finished",
+      	"type": [{
+      		"coding": [{
+      			"system": "http://www.ama-assn.org/go/cpt",
+      			"code": "99201"
+      		}],
+      		"text": "Office Visit"
+      	}],
+      	"patient": {
+      		"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f2a"
+      	},
+      	"period": {
+      		"start": "2013-09-02T10:00:00-05:00"
+      	}
+      },
+      "request": {
+        "method": "POST",
+        "url": "Encounter"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f2d",
+      "resource": {
+      	"resourceType": "Encounter",
+      	"id": "61ebe359-bfdc-4613-8bf2-c5e300945f2d",
+      	"status": "finished",
+      	"type": [{
+      		"coding": [{
+      			"system": "http://www.ama-assn.org/go/cpt",
+      			"code": "99201"
+      		}],
+      		"text": "Office Visit"
+      	}],
+      	"patient": {
+      		"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f2a"
+      	},
+      	"period": {
+      		"start": "2014-10-15T13:00:00-05:00"
+      	}
+      },
+      "request": {
+        "method": "POST",
+        "url": "Encounter"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f2e",
+      "resource": {
+      	"resourceType": "Encounter",
+      	"id": "61ebe359-bfdc-4613-8bf2-c5e300945f2e",
+      	"status": "finished",
+      	"type": [{
+      		"coding": [{
+      			"system": "http://www.ama-assn.org/go/cpt",
+      			"code": "99201"
+      		}],
+      		"text": "Office Visit"
+      	}],
+      	"patient": {
+      		"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f2a"
+      	},
+      	"period": {
+      		"start": "2015-10-05T11:30:00-05:00"
+      	}
+      },
+      "request": {
+        "method": "POST",
+        "url": "Encounter"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f2f",
+      "resource": {
+      	"resourceType": "Condition",
+      	"id": "61ebe359-bfdc-4613-8bf2-c5e300945f2f",
+      	"verificationStatus": "confirmed",
+      	"patient": {
+      		"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f2a"
+      	},
+      	"code": {
+      		"coding": [{
+      			"system": "http://snomed.info/sct",
+      			"code": "426749004"
+      		}, {
+      			"system": "http://hl7.org/fhir/sid/icd-9",
+      			"code": "427.31"
+      		}, {
+      			"system": "http://hl7.org/fhir/sid/icd-10",
+      			"code": "I48.2"
+      		}],
+      		"text": "Atrial Fibrillation"
+      	},
+      	"onsetDateTime": "2012-09-20T08:00:00-05:00"
+      },
+      "request": {
+        "method": "POST",
+        "url": "Condition"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f30",
+      "resource": {
+      	"resourceType": "Condition",
+      	"id": "61ebe359-bfdc-4613-8bf2-c5e300945f30",
+      	"verificationStatus": "confirmed",
+      	"patient": {
+      		"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f2a"
+      	},
+      	"code": {
+      		"coding": [{
+      			"system": "http://snomed.info/sct",
+      			"code": "59621000"
+      		}, {
+      			"system": "http://hl7.org/fhir/sid/icd-9",
+      			"code": "401.9"
+      		}, {
+      			"system": "http://hl7.org/fhir/sid/icd-10",
+      			"code": "I10"
+      		}],
+      		"text": "Hypertension"
+      	},
+      	"onsetDateTime": "2013-09-02T10:00:00-05:00"
+      },
+      "request": {
+        "method": "POST",
+        "url": "Condition"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f3b",
+      "resource": {
+      	"resourceType": "MedicationStatement",
+      	"id": "61ebe359-bfdc-4613-8bf2-c5e300945f3b",
+      	"status": "active",
+      	"patient": {
+      		"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f2a"
+      	},
+      	"effectivePeriod": {
+      		"start": "2013-09-02T10:00:00-05:00"
+      	},
+      	"medicationCodeableConcept": {
+      		"coding": [{
+      			"system": "http://www.nlm.nih.gov/research/umls/rxnorm/",
+      			"code": "104377"
+      		}],
+      		"text": "Lisinopril 10mg Oral Tablet"
+      	}
+      },
+      "request": {
+        "method": "POST",
+        "url": "MedicationStatement"
+      }
+    }
+  ]
+}

--- a/fixtures/john_peters_bundle.json
+++ b/fixtures/john_peters_bundle.json
@@ -1,0 +1,538 @@
+{
+  "resourceType": "Bundle",
+  "id": "bundle-transaction",
+  "type": "transaction",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a",
+      "resource": {
+				"resourceType": "Patient",
+				"id": "8374637118556222846",
+				"name": [{
+					"family": ["Peters"],
+					"given": ["John"]
+				}],
+				"gender": "male",
+				"birthDate": "1991-02-01"
+			},
+      "request": {
+				"method": "POST",
+				"url": "Patient"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0b",
+      "resource": {
+				"resourceType": "Encounter",
+				"status": "finished",
+				"type": [{
+					"coding": [{
+						"system": "http://www.ama-assn.org/go/cpt",
+						"code": "99201"
+					}],
+					"text": "Encounter, Performed: Office Visit (Code List: 2.16.840.1.113883.3.464.1003.101.12.1001)"
+				}],
+				"patient": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				},
+				"period": {
+					"start": "2011-11-01T08:00:00-04:00",
+					"end": "2011-11-01T09:00:00-04:00"
+				}
+			},
+      "request": {
+				"method": "POST",
+				"url": "Encounter"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0c",
+      "resource": {
+				"resourceType": "Encounter",
+				"status": "finished",
+				"type": [{
+					"coding": [{
+						"system": "http://www.ama-assn.org/go/cpt",
+						"code": "99201"
+					}],
+					"text": "Encounter, Performed: Office Visit (Code List: 2.16.840.1.113883.3.464.1003.101.12.1001)"
+				}],
+				"patient": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				},
+				"period": {
+					"start": "2012-10-01T08:00:00-04:00",
+					"end": "2012-10-01T09:00:00-04:00"
+				}
+			},
+      "request": {
+				"method": "POST",
+				"url": "Encounter"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0d",
+      "resource": {
+				"resourceType": "Encounter",
+				"status": "finished",
+				"type": [{
+					"coding": [{
+						"system": "http://www.ama-assn.org/go/cpt",
+						"code": "99201"
+					}],
+					"text": "Encounter, Performed: Office Visit (Code List: 2.16.840.1.113883.3.464.1003.101.12.1001)"
+				}],
+				"patient": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				},
+				"period": {
+					"start": "2012-11-01T08:00:00-04:00",
+					"end": "2012-11-01T09:00:00-04:00"
+				}
+			},
+      "request": {
+				"method": "POST",
+				"url": "Encounter"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0e",
+      "resource": {
+				"resourceType": "Encounter",
+				"status": "finished",
+				"type": [{
+					"coding": [{
+						"system": "http://snomed.info/sct",
+						"code": "171047005"
+					}],
+					"text": "Encounter, Performed: Alcohol and Drug Dependence Treatment (Code List: 2.16.840.1.113883.3.464.1003.106.12.1005)"
+				}],
+				"patient": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				},
+				"period": {
+					"start": "2012-11-01T08:45:00-04:00",
+					"end": "2012-11-01T09:00:00-04:00"
+				}
+			},
+      "request": {
+				"method": "POST",
+				"url": "Encounter"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0f",
+      "resource": {
+				"resourceType": "Condition",
+				"verificationStatus": "confirmed",
+				"patient": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				},
+				"code": {
+					"coding": [{
+						"system": "http://snomed.info/sct",
+						"code": "10091002"
+					}, {
+						"system": "http://hl7.org/fhir/sid/icd-9",
+						"code": "428.0"
+					}, {
+						"system": "http://hl7.org/fhir/sid/icd-10",
+						"code": "I50.1"
+					}],
+					"text": "Diagnosis, Active: Heart Failure (Code List: 2.16.840.1.113883.3.526.3.376)"
+				},
+				"onsetDateTime": "2012-03-01T07:00:00-05:00"
+			},
+      "request": {
+				"method": "POST",
+				"url": "Condition"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f10",
+      "resource": {
+				"resourceType": "Condition",
+				"verificationStatus": "confirmed",
+				"patient": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				},
+				"code": {
+					"coding": [{
+						"system": "http://snomed.info/sct",
+						"code": "981000124106"
+					}],
+					"text": "Diagnosis, Active: Moderate or Severe LVSD (Code List: 2.16.840.1.113883.3.526.3.1090)"
+				},
+				"onsetDateTime": "2012-03-01T07:05:00-05:00"
+			},
+      "request": {
+				"method": "POST",
+				"url": "Condition"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f11",
+      "resource": {
+				"resourceType": "Condition",
+				"verificationStatus": "confirmed",
+				"patient": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				},
+				"code": {
+					"coding": [{
+						"system": "http://snomed.info/sct",
+						"code": "123641001"
+					}, {
+						"system": "http://hl7.org/fhir/sid/icd-9",
+						"code": "411.0"
+					}, {
+						"system": "http://hl7.org/fhir/sid/icd-10",
+						"code": "I20.0"
+					}],
+					"text": "Diagnosis, Active: Ischemic Vascular Disease (Code List: 2.16.840.1.113883.3.464.1003.104.12.1003)"
+				},
+				"onsetDateTime": "2012-03-01T07:05:00-05:00"
+			},
+      "request": {
+				"method": "POST",
+				"url": "Condition"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f12",
+      "resource": {
+				"resourceType": "Condition",
+				"verificationStatus": "confirmed",
+				"patient": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				},
+				"code": {
+					"coding": [{
+						"system": "http://snomed.info/sct",
+						"code": "123641001"
+					}, {
+						"system": "http://hl7.org/fhir/sid/icd-9",
+						"code": "411.0"
+					}, {
+						"system": "http://hl7.org/fhir/sid/icd-10",
+						"code": "I20.0"
+					}],
+					"text": "Diagnosis, Active: Coronary Artery Disease No MI (Code List: 2.16.840.1.113883.3.526.3.369)"
+				},
+				"onsetDateTime": "2012-03-01T07:05:00-05:00"
+			},
+      "request": {
+				"method": "POST",
+				"url": "Condition"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f13",
+      "resource": {
+				"resourceType": "Condition",
+				"verificationStatus": "confirmed",
+				"patient": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				},
+				"code": {
+					"coding": [{
+						"system": "http://snomed.info/sct",
+						"code": "10725009"
+					}, {
+						"system": "http://hl7.org/fhir/sid/icd-9",
+						"code": "401.1"
+					}],
+					"text": "Diagnosis, Active: Hypertension (Code List: 2.16.840.1.113883.3.464.1003.104.12.1016)"
+				},
+				"onsetDateTime": "2012-03-01T07:30:00-05:00"
+			},
+      "request": {
+				"method": "POST",
+				"url": "Condition"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f14",
+      "resource": {
+				"resourceType": "Observation",
+				"status": "final",
+				"code": {
+					"coding": [{
+						"system": "http://loinc.org",
+						"code": "17856-6"
+					}],
+					"text": "Laboratory Test, Result: HbA1c Laboratory Test"
+				},
+				"valueQuantity": {
+					"value": 8,
+					"unit": "%"
+				},
+				"effectivePeriod": {
+					"start": "2011-11-01T08:16:40-04:00",
+					"end": "2011-11-01T08:16:40-04:00"
+				},
+				"status": "final",
+				"subject": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				},
+				"encounter": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0b"
+				}
+			},
+      "request": {
+				"method": "POST",
+				"url": "Observation"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f15",
+      "resource": {
+				"resourceType": "Procedure",
+				"status": "completed",
+				"subject": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				},
+				"code": {
+					"coding": [{
+						"system": "http://snomed.info/sct",
+						"code": "116783008"
+					}],
+					"text": "Procedure, Result: Clinical Staging Procedure"
+				},
+				"performedPeriod": {
+					"start": "2011-11-01T08:16:40-04:00",
+					"end": "2011-11-01T11:03:20-04:00"
+				},
+				"encounter": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0b"
+				},
+				"report": [{
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f16"
+				}],
+				"notes": [{
+			    "text": "Procedure, Result: Clinical Staging Procedure"
+			  }]
+			},
+      "request": {
+				"method": "POST",
+				"url": "Procedure"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f16",
+      "resource": {
+				"resourceType": "DiagnosticReport",
+				"status": "final",
+				"code": {
+					"coding": [{
+						"system": "http://snomed.info/sct",
+						"code": "116783008"
+					}],
+					"text": "Procedure, Result: Clinical Staging Procedure"
+				},
+				"subject": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				},
+				"effectiveDateTime": "2011-11-01T11:03:20-04:00",
+				"issued": "2011-11-02T13:30:00-04:00",
+				"performer": {
+				  "reference": "Organization/4072118964683285544",
+				  "display": "Acme Laboratory, Inc"
+				},
+				"result": [{
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f17"
+				}, {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f18"
+				}, {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f19"
+				}]
+			},
+      "request": {
+				"method": "POST",
+				"url": "DiagnosticReport"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f17",
+      "resource": {
+				"resourceType": "Observation",
+				"status": "final",
+				"code": {
+					"coding": [{
+						"system": "http://snomed.info/sct",
+						"code": "116783008"
+					}],
+					"text": "Procedure, Result: Clinical Staging Procedure"
+				},
+				"valueCodeableConcept": {
+					"coding": [{
+						"system": "http://snomed.info/sct",
+						"code": "433581000124101"
+					}],
+					"text": "Colon Distant Metastasis Status M0"
+				},
+				"effectivePeriod": {
+					"start": "2011-11-01T08:16:40-04:00",
+					"end": "2011-11-01T11:03:20-04:00"
+				},
+				"status": "final",
+				"subject": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				}
+			},
+      "request": {
+				"method": "POST",
+				"url": "Observation"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f18",
+      "resource": {
+				"resourceType": "Observation",
+				"status": "final",
+				"code": {
+					"coding": [{
+						"system": "http://snomed.info/sct",
+						"code": "116783008"
+					}],
+					"text": "Procedure, Result: Clinical Staging Procedure"
+				},
+				"valueCodeableConcept": {
+					"coding": [{
+						"system": "http://snomed.info/sct",
+						"code": "433571000124104"
+					}],
+					"text": "Colon Cancer Regional Lymph Node Status N2b"
+				},
+				"effectivePeriod": {
+					"start": "2011-11-01T08:16:40-04:00",
+					"end": "2011-11-01T11:03:20-04:00"
+				},
+				"status": "final",
+				"subject": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				}
+			},
+      "request": {
+				"method": "POST",
+				"url": "Observation"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f19",
+      "resource": {
+				"resourceType": "Observation",
+				"status": "final",
+				"code": {
+					"coding": [{
+						"system": "http://snomed.info/sct",
+						"code": "116783008"
+					}],
+					"text": "Procedure, Result: Clinical Staging Procedure"
+				},
+				"valueCodeableConcept": {
+					"coding": [{
+						"system": "http://snomed.info/sct",
+						"code": "433491000124102"
+					}],
+					"text": "Colon Cancer Primary Tumor Size T4a"
+				},
+				"effectivePeriod": {
+					"start": "2011-11-01T08:16:40-04:00",
+					"end": "2011-11-01T11:03:20-04:00"
+				},
+				"status": "final",
+				"subject": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				}
+			},
+      "request": {
+				"method": "POST",
+				"url": "Observation"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f1a",
+      "resource": {
+				"resourceType": "Procedure",
+				"status": "completed",
+				"subject": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				},
+				"code": {
+					"coding": [{
+						"system": "http://hl7.org/fhir/sid/icd-9",
+						"code": "36.10"
+					}, {
+						"system": "http://hl7.org/fhir/sid/icd-10",
+						"code": "0210093"
+					}, {
+						"system": "http://snomed.info/sct",
+						"code": "10190003"
+					}],
+					"text": "Procedure, Performed: Hospital measures-CABG"
+				},
+				"performedPeriod": {
+					"start": "2013-03-02T10:45:00-05:00",
+					"end": "2013-03-02T11:45:00-05:00"
+				},
+				"notes": [{
+			    "text": "Procedure, Performed: Hospital measures-CABG"
+			  }]
+			},
+      "request": {
+				"method": "POST",
+				"url": "Procedure"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f1b",
+      "resource": {
+				"resourceType": "MedicationStatement",
+				"status": "completed",
+				"patient": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				},
+				"effectivePeriod": {
+					"start": "2012-10-01T08:00:00-04:00",
+					"end": "2012-10-01T08:00:00-04:00"
+				},
+				"medicationCodeableConcept": {
+					"coding": [{
+						"system": "http://www.nlm.nih.gov/research/umls/rxnorm/",
+						"code": "1000048"
+					}],
+					"text": "Medication, Order: BH Antidepressant medication (Code List: 2.16.840.1.113883.3.1257.1.972)"
+				}
+			},
+      "request": {
+				"method": "POST",
+				"url": "MedicationStatement"
+      }
+    },
+		{
+      "fullUrl": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f1c",
+      "resource": {
+				"resourceType": "Immunization",
+				"status": "completed",
+				"date": "2011-08-15T08:00:00-04:00",
+				"vaccineCode": {
+					"coding": [{
+						"system": "http://www2a.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=cvx",
+						"code": "33"
+					}],
+					"text": "Medication, Administered: Pneumococcal Vaccine (Code List: 2.16.840.1.113883.3.464.1003.110.12.1027)"
+				},
+				"patient": {
+					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
+				},
+				"wasNotGiven": false,
+				"reported": false
+			},
+      "request": {
+				"method": "POST",
+				"url": "Immunization"
+      }
+    }
+	]
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c5b85d86f9fa14afd6048eb722f124254903f28feabc218c19b7ce5e162271c4
-updated: 2017-01-26T12:01:46.022785638-05:00
+hash: d21a0d7d2f549d87f4ac0db8e4f1d409b7c8e8203038dd74da687a50e652e2e0
+updated: 2017-01-26T13:12:03.119880116-05:00
 imports:
 - name: github.com/boj/redistore
   version: fc113767cd6b051980f260d6dbe84b2740c46ab0
@@ -35,7 +35,7 @@ imports:
   version: 84bff6d01560fb0b5a396ba29534e93fd00d09c6
 - name: github.com/intervention-engine/fhir
   version: ffdbbf0fd38eef4edef052773901d71a5ff7a488
-  repo: git@github.com:intervention-engine/fhir.git
+  repo: https://github.com/intervention-engine/fhir.git
   vcs: git
   subpackages:
   - auth

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,21 @@
-hash: f37f4643972a57f9d731644f1de7c8a2b4e8cb01260ced19bcd8196ff923ad0d
-updated: 2017-01-24T11:22:12.844617358-05:00
+hash: c5b85d86f9fa14afd6048eb722f124254903f28feabc218c19b7ce5e162271c4
+updated: 2017-01-26T12:01:46.022785638-05:00
 imports:
+- name: github.com/boj/redistore
+  version: fc113767cd6b051980f260d6dbe84b2740c46ab0
+- name: github.com/davecgh/go-spew
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  subpackages:
+  - spew
+- name: github.com/garyburd/redigo
+  version: 908534c8b97586a4597e3fa195875d2d26502b97
+  subpackages:
+  - internal
+  - redis
+- name: github.com/gin-gonic/contrib
+  version: 4d2dccc9a4541014fec054e483cc76609b97fb16
+  subpackages:
+  - sessions
 - name: github.com/gin-gonic/gin
   version: e2212d40c62a98b388a5eb48ecbdcf88534688ba
   subpackages:
@@ -10,43 +25,82 @@ imports:
   version: 2402d76f3d41f928c7902a765dfc872356dd3aad
   subpackages:
   - proto
+- name: github.com/gorilla/context
+  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
+- name: github.com/gorilla/securecookie
+  version: fa5329f913702981df43dcb2a380bac429c810b5
+- name: github.com/gorilla/sessions
+  version: 83c8db3bdc9be789e57e3756ffbcffd2d7d40176
+- name: github.com/icrowley/fake
+  version: 84bff6d01560fb0b5a396ba29534e93fd00d09c6
 - name: github.com/intervention-engine/fhir
-  version: 18418abbece6c11d0522fb9e99ed1e72b06547ce
+  version: ffdbbf0fd38eef4edef052773901d71a5ff7a488
+  repo: git@github.com:intervention-engine/fhir.git
+  vcs: git
   subpackages:
+  - auth
   - models
+  - search
+  - server
+- name: github.com/itsjamie/gin-cors
+  version: 97b4a9da79331dfa2b6d35f4cdd1e50f5148859c
+- name: github.com/juju/errors
+  version: 6f54ff6318409d31ff16261533ce2c8381a4fd5d
 - name: github.com/manucorporat/sse
   version: ee05b128a739a0fb76c7ebd3ae4810c1de808d6d
 - name: github.com/mattn/go-isatty
   version: 30a891c33c7cde7b02a981314b4228ec99380cca
+- name: github.com/mitre/heart
+  version: 0c46b433a490476c34ce33205e87a72c8e0bc7ef
+- name: github.com/pmezard/go-difflib
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  subpackages:
+  - difflib
+- name: github.com/stretchr/testify
+  version: f390dcf405f7b83c997eac1b06768bb9f44dec18
+  subpackages:
+  - assert
+  - require
+  - suite
 - name: golang.org/x/net
   version: f315505cf3349909cdf013ea56690da34e96a451
   subpackages:
   - context
+- name: golang.org/x/oauth2
+  version: 314dd2c0bf3ebd592ec0d20847d27e79d0dbe8dd
+  subpackages:
+  - internal
 - name: golang.org/x/sys
   version: d75a52659825e75fff6158388dddc6a5b04f9ba5
   subpackages:
   - unix
+- name: google.golang.org/appengine
+  version: a2c54d2174c17540446e0ced57d9d459af61bc1c
+  subpackages:
+  - internal
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
 - name: gopkg.in/go-playground/validator.v8
   version: c193cecd124b5cc722d7ee5538e945bdb3348435
 - name: gopkg.in/mgo.v2
   version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
   subpackages:
   - bson
+  - dbtest
   - internal/json
+  - internal/sasl
+  - internal/scram
+- name: gopkg.in/square/go-jose.v1
+  version: aa2e30fdd1fe9dd3394119af66451ae790d50e0d
+  subpackages:
+  - cipher
+  - json
+- name: gopkg.in/tomb.v2
+  version: d5d1b5820637886def9eef33e03a27a9f166942c
 - name: gopkg.in/yaml.v2
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
-testImports:
-- name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
-  subpackages:
-  - spew
-- name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
-  subpackages:
-  - difflib
-- name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
-  subpackages:
-  - assert
-  - require
-  - suite
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,12 +1,17 @@
 package: github.com/mitre/ptmerge
 import:
 - package: github.com/gin-gonic/gin
-  version: v1.1.4
 - package: github.com/intervention-engine/fhir
+  vcs: git
+  version: stu3_aug2016
+  repo: git@github.com:intervention-engine/fhir.git
   subpackages:
   - models
-testImport:
+  - server
 - package: github.com/stretchr/testify
-  version: v1.1.4
   subpackages:
   - suite
+- package: gopkg.in/mgo.v2
+  subpackages:
+  - bson
+  - dbtest

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,7 +4,7 @@ import:
 - package: github.com/intervention-engine/fhir
   vcs: git
   version: stu3_aug2016
-  repo: git@github.com:intervention-engine/fhir.git
+  repo: https://github.com/intervention-engine/fhir.git
   subpackages:
   - models
   - server

--- a/merge/merger.go
+++ b/merge/merger.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Merger is the top-level interface used to merge resources and resolve conflicts.
-type Merger struct{}
+type Merger struct {}
 
 // Merge attempts to merge two FHIR Bundles containing patient records. If a merge
 // is successful a new FHIR Bundle containing the merged patient record is returned.

--- a/server/merge_controller.go
+++ b/server/merge_controller.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gopkg.in/mgo.v2"
+)
+
+// MergeController manages the resource handles for a Merge.
+type MergeController struct {
+	session  *mgo.Session
+	fhirHost string
+}
+
+// NewMergeController returns a pointer to a newly initialized MergeController.
+func NewMergeController(session *mgo.Session, fhirHost string) *MergeController {
+	return &MergeController{
+		session:  session,
+		fhirHost: fhirHost,
+	}
+}
+
+// Merges 2 FHIR bundles of patient resources given the URLs to both bundles.
+func (m *MergeController) merge(c *gin.Context) {
+	source1 := c.Query("source1")
+	source2 := c.Query("source2")
+	c.String(http.StatusOK, "Merging records %s and %s", source1, source2)
+}
+
+// Resolves a single merge confict given the OperationOutcome ID and the correct resource
+// that resolves the merge.
+func (m *MergeController) resolve(c *gin.Context) {
+	mergeID := c.Param("merge_id")
+	opOutcomeID := c.Param("op_outcome_id")
+	c.String(http.StatusOK, "Resolving conflict %s for merge %s", opOutcomeID, mergeID)
+}
+
+// Aborts a merge given the merge's ID.
+func (m *MergeController) abort(c *gin.Context) {
+	mergeID := c.Param("merge_id")
+	c.String(http.StatusOK, "Aborting merge %s", mergeID)
+}
+
+// Returns all unresolved merge conflicts for a given merge ID.
+func (m *MergeController) getConflicts(c *gin.Context) {
+	mergeID := c.Param("merge_id")
+	c.String(http.StatusOK, "Merge conflicts for merge %s", mergeID)
+}

--- a/server/routing.go
+++ b/server/routing.go
@@ -1,49 +1,20 @@
 package server
 
 import (
-	"fmt"
-	"net/http"
-
 	"github.com/gin-gonic/gin"
+	"gopkg.in/mgo.v2"
 )
 
 // RegisterRoutes registers all routes needed to serve the patient matching service.
-func RegisterRoutes(router *gin.Engine) {
+func RegisterRoutes(router *gin.Engine, session *mgo.Session, fhirHost string) {
+
+	mc := NewMergeController(session, fhirHost)
 
 	// Merging and confict resolution
-	router.POST("/merge", merge)
-	router.POST("/merge/:merge_id/resolve/:op_outcome_id", resolve)
-	router.POST("/merge/:merge_id/abort", abort)
-	router.GET("/merge/:merge_id", getConflicts)
-}
+	router.POST("/merge", mc.merge)
+	router.POST("/merge/:merge_id/resolve/:op_outcome_id", mc.resolve)
+	router.POST("/merge/:merge_id/abort", mc.abort)
 
-// Merges 2 FHIR bundles of patient resources given the URLs to both bundles.
-func merge(c *gin.Context) {
-	source1 := c.Query("source1")
-	source2 := c.Query("source2")
-
-	fmt.Printf("Source 1: %s\n", source1)
-	fmt.Printf("Source 2: %s\n", source2)
-
-	c.String(http.StatusOK, "Merging records %s and %s", source1, source2)
-}
-
-// Resolves a single merge confict given the OperationOutcome ID and the correct resource
-// that resolves the merge.
-func resolve(c *gin.Context) {
-	mergeID := c.Param("merge_id")
-	opOutcomeID := c.Param("op_outcome_id")
-	c.String(http.StatusOK, "Resolving conflict %s for merge %s", opOutcomeID, mergeID)
-}
-
-// Aborts a merge given the merge's ID.
-func abort(c *gin.Context) {
-	mergeID := c.Param("merge_id")
-	c.String(http.StatusOK, "Aborting merge %s", mergeID)
-}
-
-// Returns all unresolved merge conflicts for a given merge ID.
-func getConflicts(c *gin.Context) {
-	mergeID := c.Param("merge_id")
-	c.String(http.StatusOK, "Merge conflicts for merge %s", mergeID)
+	// Convenience methods
+	router.GET("/merge/:merge_id", mc.getConflicts)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,22 +1,30 @@
 package server
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 
 	"io/ioutil"
 
 	"github.com/gin-gonic/gin"
+	"github.com/intervention-engine/fhir/models"
+	"github.com/intervention-engine/fhir/server"
+	"github.com/mitre/ptmerge/testutil"
 	"github.com/stretchr/testify/suite"
 )
 
 type ServerTestSuite struct {
-	suite.Suite
-	Engine *gin.Engine
-	Server *httptest.Server
+	// The MongoSuite from IE provides useful features for starting/stopping
+	// a test mongo database, as well as inserting test fixtures.
+	testutil.MongoSuite
+	PTMergeServer *httptest.Server
+	FHIRServer    *httptest.Server
+	patientIDs    []string
 }
 
 func TestServerTestSuite(t *testing.T) {
@@ -24,31 +32,71 @@ func TestServerTestSuite(t *testing.T) {
 }
 
 func (s *ServerTestSuite) SetupSuite() {
-	// set gin to release mode (less verbose output)
+	// Set gin to release mode (less verbose output).
 	gin.SetMode(gin.ReleaseMode)
 
-	// build routes for testing
-	s.Engine = gin.New()
-	RegisterRoutes(s.Engine)
+	// Create a mock FHIR server to check the ptmerge service's outgoing requests. The first
+	// call to s.DB() stands up the mock Mongo server, see testutil/mongo_suite.go for more.
+	fhirEngine := gin.New()
+	ms := server.NewMasterSession(s.DB().Session, "ptmerge-test")
+	server.RegisterRoutes(fhirEngine, nil, server.NewMongoDataAccessLayer(ms, nil), server.Config{})
+	s.FHIRServer = httptest.NewServer(fhirEngine)
 
-	// create HTTP test server
-	s.Server = httptest.NewServer(s.Engine)
+	// POST test fixtures (bundles) to the mock FHIR server.
+	s.patientIDs = append(s.patientIDs, s.postPatientBundle("../fixtures/john_peters_bundle.json"))
+	s.patientIDs = append(s.patientIDs, s.postPatientBundle("../fixtures/clint_abbot_bundle.json"))
+
+	// Create a mock PTMergeServer.
+	ptmergeEngine := gin.New()
+	RegisterRoutes(ptmergeEngine, s.DB().Session, s.FHIRServer.URL)
+	s.PTMergeServer = httptest.NewServer(ptmergeEngine)
+}
+
+// Inserts a fixture into the mock FHIR server.
+func (s *ServerTestSuite) postPatientBundle(fixturePath string) string {
+	// Load and POST the fixture.
+	data, err := os.Open(fixturePath)
+	s.NoError(err)
+	defer data.Close()
+	res, err := http.Post(s.FHIRServer.URL+"/", "application/json", data)
+	s.NoError(err)
+	defer res.Body.Close()
+
+	// Check the response.
+	s.Equal(http.StatusOK, res.StatusCode)
+	decoder := json.NewDecoder(res.Body)
+	responseBundle := &models.Bundle{}
+	err = decoder.Decode(responseBundle)
+	s.NoError(err)
+	s.Equal("transaction-response", responseBundle.Type)
+
+	// Return the new ID of the Patient resource.
+	patient, ok := responseBundle.Entry[0].Resource.(*models.Patient)
+	s.True(ok)
+	s.Equal("Patient", patient.Resource.ResourceType)
+	return patient.Resource.Id
 }
 
 func (s *ServerTestSuite) TeardownSuite() {
-	s.Server.Close()
+	s.PTMergeServer.Close()
+	s.FHIRServer.Close()
+	// Clean up and remove all temporary files from the mocked database.
+	// See testutil/mongo_suite.go for more.
+	s.TearDownDBServer()
 }
 
 func (s *ServerTestSuite) TestInitiateMerge() {
-	source1 := "http://www.example.com/fhir/Patient/12345"
-	source2 := "http://www.example.com/fhir/Patient/67890"
-	req := s.Server.URL + "/merge?source1=" + url.QueryEscape(source1) + "&source2=" + url.QueryEscape(source2)
+	source1 := s.FHIRServer.URL + "/Patient?_id=" + s.patientIDs[0] + "&_include=*&_revinclude=*"
+	source2 := source1
+	req := s.PTMergeServer.URL + "/merge?source1=" + url.QueryEscape(source1) + "&source2=" + url.QueryEscape(source2)
 
 	res, err := http.Post(req, "", nil)
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	s.NoError(err)
 
-	s.Nil(err)
+	body, err := ioutil.ReadAll(res.Body)
+	s.NoError(err)
+
 	s.Equal(200, res.StatusCode)
 	s.Equal(fmt.Sprintf("Merging records %s and %s", source1, source2), string(body))
 }
@@ -56,39 +104,45 @@ func (s *ServerTestSuite) TestInitiateMerge() {
 func (s *ServerTestSuite) TestResolveConflict() {
 	mergeID := "12345"
 	conflictID := "67890"
-	req := s.Server.URL + "/merge/" + mergeID + "/resolve/" + conflictID
+	req := s.PTMergeServer.URL + "/merge/" + mergeID + "/resolve/" + conflictID
 
 	res, err := http.Post(req, "", nil)
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	s.NoError(err)
 
-	s.Nil(err)
+	body, err := ioutil.ReadAll(res.Body)
+	s.NoError(err)
+
 	s.Equal(200, res.StatusCode)
 	s.Equal(fmt.Sprintf("Resolving conflict %s for merge %s", conflictID, mergeID), string(body))
 }
 
 func (s *ServerTestSuite) TestAbortMerge() {
 	mergeID := "12345"
-	req := s.Server.URL + "/merge/" + mergeID + "/abort"
+	req := s.PTMergeServer.URL + "/merge/" + mergeID + "/abort"
 
 	res, err := http.Post(req, "", nil)
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	s.NoError(err)
 
-	s.Nil(err)
+	body, err := ioutil.ReadAll(res.Body)
+	s.NoError(err)
+
 	s.Equal(200, res.StatusCode)
 	s.Equal(fmt.Sprintf("Aborting merge %s", mergeID), string(body))
 }
 
 func (s *ServerTestSuite) TestGetConflicts() {
 	mergeID := "12345"
-	req := s.Server.URL + "/merge/" + mergeID
+	req := s.PTMergeServer.URL + "/merge/" + mergeID
 
 	res, err := http.Get(req)
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	s.NoError(err)
 
-	s.Nil(err)
+	body, err := ioutil.ReadAll(res.Body)
+	s.NoError(err)
+
 	s.Equal(200, res.StatusCode)
 	s.Equal(fmt.Sprintf("Merge conflicts for merge %s", mergeID), string(body))
 }

--- a/testutil/mongo_suite.go
+++ b/testutil/mongo_suite.go
@@ -1,0 +1,195 @@
+package testutil
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/mgo.v2/dbtest"
+)
+
+// From github.com/intervention-engine/ie/testutil
+
+// MongoSuite is a testify Suite that adds functions to setup and teardown test Mongo DBs, as well as other provides
+// functions for other common Mongo-related tasks such as inserting a fixture into the database.
+type MongoSuite struct {
+	suite.Suite
+	dbServer      *dbtest.DBServer
+	dbServerPath  string
+	dbServerMutex sync.Mutex
+	db            *mgo.Database
+	dbMutex       sync.Mutex
+}
+
+// DBServer returns a pointer to the suite's test Mongo DBServer, initializing a new one if necessary.  Subsequent calls
+// will return the same DBServer until TearDownDBServer is called.  In most cases, calls to DBServer() are completely
+// unnecessary, as calls to DB() will automatically instantiate the DBServer if needed.  If a test suite calls
+// DBServer(), then TearDownDBServer() MUST be called in the TearDownSuite function (or TearDownTest, if appropriate).
+func (suite *MongoSuite) DBServer() *dbtest.DBServer {
+	suite.dbServerMutex.Lock()
+	defer suite.dbServerMutex.Unlock()
+
+	if suite.dbServer == nil {
+		var err error
+		suite.dbServer = &dbtest.DBServer{}
+		suite.dbServerPath, err = ioutil.TempDir("", "mongotestdb")
+		suite.Require().NoError(err)
+		suite.dbServer.SetPath(suite.dbServerPath)
+	}
+	return suite.dbServer
+}
+
+// TearDownDBServer cleans up the suite's test Mongo DBServer, including closing any open sessions, wiping the data,
+// stopping the test DBServer, and deleting the temporary directory where the DBServer stored files.  This function
+// would typically be called in the test suite's TearDownSuite function.
+func (suite *MongoSuite) TearDownDBServer() {
+	suite.TearDownDB()
+
+	suite.dbServerMutex.Lock()
+	defer suite.dbServerMutex.Unlock()
+
+	if suite.dbServer != nil {
+		suite.dbServer.Wipe()
+		suite.dbServer.Stop()
+		suite.dbServer = nil
+	}
+
+	if suite.dbServerPath != "" {
+		if err := os.RemoveAll(suite.dbServerPath); err != nil {
+			fmt.Fprintf(os.Stderr, "WARNING: Error cleaning up temp directory: %s", err.Error())
+		}
+	}
+}
+
+// DB returns a pointer to the suite's test Database, named "ptmerge-test", initializing a new Database, Session, and/or
+// DBServer if necessary.  Subsequent calls will return the same Database until TearDownDB() is called.  If a test suite
+// calls DB(), then TearDownDBServer() MUST be called in the TearDownSuite function (or TearDownTest, if appropriate).
+func (suite *MongoSuite) DB() *mgo.Database {
+	suite.dbMutex.Lock()
+	defer suite.dbMutex.Unlock()
+
+	if suite.db == nil {
+		suite.db = suite.DBServer().Session().DB("ptmerge-test")
+	}
+	return suite.db
+}
+
+// TearDownDB closes the suite's test Session and wipes the DBServer (thereby removing the Database).  This function
+// would typically be called in the test suite's TearDownTest function.
+func (suite *MongoSuite) TearDownDB() {
+	suite.dbMutex.Lock()
+	defer suite.dbMutex.Unlock()
+
+	if suite.db != nil {
+		suite.db.Session.Close()
+		suite.db = nil
+		// suite.dbServer should never be nil at this point, but better safe than sorry
+		suite.dbServerMutex.Lock()
+		if suite.dbServer != nil {
+			suite.dbServer.Wipe()
+		}
+		suite.dbServerMutex.Unlock()
+	}
+}
+
+// InsertFixture inserts a test fixture into the Mongo database.  If the fixture does not have an _id set, InsertFixture
+// will attempt to find the _id field using reflection and will set it to a new BSON ID before inserting.
+func (suite *MongoSuite) InsertFixture(collection string, pathToFixture string, doc interface{}) {
+	require := suite.Require()
+
+	// Read the fixture file and unmarshal it to the doc
+	data, err := ioutil.ReadFile(pathToFixture)
+	require.NoError(err)
+	err = json.Unmarshal(data, doc)
+	require.NoError(err)
+
+	// If it's a slice, store each element, otherwise just store the thing
+	value := reflect.ValueOf(doc).Elem()
+	if value.Kind() == reflect.Slice {
+		for i := 0; i < value.Len(); i++ {
+			suite.insertValue(collection, value.Index(i))
+		}
+	} else {
+		suite.insertValue(collection, value)
+	}
+}
+
+// PrintDBServerInfo logs out the connection info for the current test database.
+func (suite *MongoSuite) PrintDBServerInfo() {
+	suite.dbServerMutex.Lock()
+	defer suite.dbServerMutex.Unlock()
+
+	dbs := suite.dbServer
+	if dbs == nil {
+		log.Println("Test database server is not running.")
+		return
+	}
+
+	suite.dbMutex.Lock()
+	defer suite.dbMutex.Unlock()
+
+	var session *mgo.Session
+	if suite.db != nil {
+		session = suite.db.Session
+	} else {
+		session = dbs.Session()
+		defer session.Close()
+	}
+
+	log.Println("Test Mongo Database Info {")
+	for _, addr := range session.LiveServers() {
+		log.Println("  Address:       ", addr)
+	}
+	if dbNames, err := session.DatabaseNames(); err == nil {
+		log.Println("  Databases:     [ ", strings.Join(dbNames, ", "), " ]")
+	}
+	if info, err := session.BuildInfo(); err == nil {
+		log.Println("  Version:       ", info.Version)
+		log.Println("  GitVersion:    ", info.GitVersion)
+		log.Println("  OpenSSLVersion:", info.OpenSSLVersion)
+		log.Println("  Bits:          ", info.Bits)
+		log.Println("  MaxObjectSize: ", info.MaxObjectSize)
+		log.Println("  Debug:         ", info.Debug)
+	}
+	log.Println("}")
+
+}
+
+func (suite *MongoSuite) insertValue(collection string, value reflect.Value) {
+	// Find the ID field and set it, if necessary
+	if field, err := findBSONIDField(value); err == nil && field.CanSet() && field.String() == "" {
+		field.SetString(bson.NewObjectId().Hex())
+	}
+
+	// Store it
+	err := suite.DB().C(collection).Insert(value.Interface())
+	suite.Require().NoError(err)
+}
+
+func findBSONIDField(value reflect.Value) (reflect.Value, error) {
+	for i := 0; i < value.NumField(); i++ {
+		valueField := value.Field(i)
+		typeField := value.Type().Field(i)
+		bsonTag := typeField.Tag.Get("bson")
+		if strings.HasPrefix(bsonTag, ",inline") {
+			// It's an inline struct, so check it for an _id
+			if idField, err := findBSONIDField(valueField); err == nil {
+				return idField, nil
+			}
+		} else if strings.HasPrefix(bsonTag, "_id") {
+			return valueField, nil
+		} else if typeField.Name == "_id" && (bsonTag == "" || strings.HasPrefix(bsonTag, ",")) {
+			return valueField, nil
+		}
+	}
+	return reflect.Value{}, errors.New("No _id field found")
+}


### PR DESCRIPTION
Added the `MergeController` struct to pass the mongodb connection and FHIR host to the various routes. Added a mock FHIR server and mongodb server to `server_test.go`, as well as 2 patient bundles that get inserted into the FHIR database during `SetupSuite()`.

The server test suite builds off of the `MongoSuite` testing utility from `intervention-engine/ie/testutil`, and uses patient bundle fixtures from `intervention-engine/fhir`. These fixtures may or may not meet our testing needs, but they're something to start with.

I also updated our dependencies with Glide. Most notably, I fixed the `intervention-engine/fhir` dependency on the `stu3_aug2016` branch (FHIR 1.6). This may need to be changed soon if the FHIR server gets updated to FHIR 1.8.