### PR TITLE
Merger initialization updates

### DIFF
--- a/merge/merger.go
+++ b/merge/merger.go
@@ -1,17 +1,26 @@
 package merge
 
-import (
-	"github.com/intervention-engine/fhir/models"
-)
+import "github.com/intervention-engine/fhir/models"
 
 // Merger is the top-level interface used to merge resources and resolve conflicts.
-type Merger struct {}
+// The Merger is solely responsible for communicating with the FHIR host and managing
+// resources on that host.
+type Merger struct {
+	fhirHost string
+}
+
+// NewMerger returns a pointer to a newly initialized Merger with a known FHIR host.
+func NewMerger(fhirHost string) *Merger {
+	return &Merger{
+		fhirHost: fhirHost,
+	}
+}
 
 // Merge attempts to merge two FHIR Bundles containing patient records. If a merge
 // is successful a new FHIR Bundle containing the merged patient record is returned.
 // If a merge fails, a FHIR Bundle containing one or more OperationOutcomes is
 // returned detailing the merge conflicts.
-func (m *Merger) Merge(source1ID, source2ID string) (outcome *models.Bundle, err error) {
+func (m *Merger) Merge(source1ID, source2ID string) (mergeID string, outcome *models.Bundle, err error) {
 	return
 }
 
@@ -25,8 +34,8 @@ func (m *Merger) ResolveConflict(mergeID, opOutcomeID string, updatedResource in
 }
 
 // Abort aborts a merge in progress. The partially merged Bundle and any outstanding
-// OperationOutcomes are deleted. A successful OperationOutcome is returned to the
-// client in response.
-func (m *Merger) Abort(mergeID string) (outcome *models.OperationOutcome, err error) {
+// OperationOutcomes are deleted. A Bundle with a successful OperationOutcome is returned
+// to the client in response.
+func (m *Merger) Abort(mergeID string) (outcome *models.Bundle, err error) {
 	return
 }

--- a/merge/merger_test.go
+++ b/merge/merger_test.go
@@ -16,7 +16,8 @@ func TestMergerTestSuite(t *testing.T) {
 
 func (m *MergerTestSuite) TestMerge() {
 	merger := new(Merger)
-	outcome, err := merger.Merge("12345", "67890")
+	mergeID, outcome, err := merger.Merge("12345", "67890")
+	m.Equal("", mergeID)
 	m.Nil(outcome)
 	m.Nil(err)
 }

--- a/server/merge_controller.go
+++ b/server/merge_controller.go
@@ -4,10 +4,14 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/intervention-engine/fhir/models"
+	"github.com/mitre/ptmerge/merge"
 	"gopkg.in/mgo.v2"
 )
 
-// MergeController manages the resource handles for a Merge.
+// MergeController manages the resource handlers for a Merge. MergeController
+// is also responsible for maintaining the state of a Merge using the mongo
+// database.
 type MergeController struct {
 	session  *mgo.Session
 	fhirHost string
@@ -25,20 +29,37 @@ func NewMergeController(session *mgo.Session, fhirHost string) *MergeController 
 func (m *MergeController) merge(c *gin.Context) {
 	source1 := c.Query("source1")
 	source2 := c.Query("source2")
+
+	merger := merge.NewMerger(m.fhirHost)
+
+	// Explicitly not collecting the return values from this stub.
+	merger.Merge(source1, source2)
 	c.String(http.StatusOK, "Merging records %s and %s", source1, source2)
 }
 
 // Resolves a single merge confict given the OperationOutcome ID and the correct resource
 // that resolves the merge.
 func (m *MergeController) resolve(c *gin.Context) {
+	var resource models.Resource
 	mergeID := c.Param("merge_id")
 	opOutcomeID := c.Param("op_outcome_id")
+	c.BindJSON(&resource)
+
+	merger := merge.NewMerger(m.fhirHost)
+
+	// Explicitly not collecting the return values from this stub.
+	merger.ResolveConflict(mergeID, opOutcomeID, resource)
 	c.String(http.StatusOK, "Resolving conflict %s for merge %s", opOutcomeID, mergeID)
 }
 
 // Aborts a merge given the merge's ID.
 func (m *MergeController) abort(c *gin.Context) {
 	mergeID := c.Param("merge_id")
+
+	merger := merge.NewMerger(m.fhirHost)
+
+	// Explicitly not collecting the return values from this stub.
+	merger.Abort(mergeID)
 	c.String(http.StatusOK, "Aborting merge %s", mergeID)
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -104,9 +105,22 @@ func (s *ServerTestSuite) TestInitiateMerge() {
 func (s *ServerTestSuite) TestResolveConflict() {
 	mergeID := "12345"
 	conflictID := "67890"
+	resource := []byte(`
+	{
+		"resourceType": "Patient",
+		"id": "61ebe359-bfdc-4613-8bf2-c5e300945f2a",
+		"name": [{
+			"family": ["Abbott"],
+			"given": ["Clint"]
+		}],
+		"gender": "male",
+		"birthDate": "1950-09-02"
+	}
+	`)
+
 	req := s.PTMergeServer.URL + "/merge/" + mergeID + "/resolve/" + conflictID
 
-	res, err := http.Post(req, "", nil)
+	res, err := http.Post(req, "application/json", bytes.NewBuffer(resource))
 	defer res.Body.Close()
 	s.NoError(err)
 


### PR DESCRIPTION
The FHIR host is now passed to the merger. The Merger now returns a new mergeID after a merge is initiated.