### PR TITLE
Unset conflict URL after it's deleted

### DIFF
--- a/server/merge_controller.go
+++ b/server/merge_controller.go
@@ -203,8 +203,10 @@ func (m *MergeController) Resolve(c *gin.Context) {
 				return
 			}
 
-			// Mark the conflict as "deleted".
+			// Mark the conflict as "deleted". Also clear it's URL, since the URL is no
+			// longer a valid reference to a FHIR resource.
 			mergeState.Conflicts[id].Deleted = true
+			mergeState.Conflicts[id].URL = ""
 		}
 
 		// Update the merge to "completed".
@@ -262,7 +264,9 @@ func (m *MergeController) Abort(c *gin.Context) {
 	var URLs []string
 
 	if mergeState.Completed {
-		// If the merge is complete, just delete it's target.
+		// If the merge is complete, just delete it's target. This operates on the assumption
+		// that conflict OperationOutcomes are deleted after a call to ResolveConflict resolves
+		// the last remaining conflict.
 		URLs = []string{mergeState.TargetURL}
 	} else {
 		// If a merge is incomplete, delete it's target and all conflicts.

--- a/state/state.go
+++ b/state/state.go
@@ -19,14 +19,14 @@ type Merge struct {
 type MergeState struct {
 	MergeID   string      `bson:"_id,omitempty" json:"id,omitempty"`
 	Completed bool        `bson:"completed" json:"completed"`
-	TargetURL string      `bson:"target,omitempty" json:"target,omitempty"`
+	TargetURL string      `bson:"target" json:"target"`
 	Conflicts ConflictMap `bson:"conflicts,omitempty" json:"conflicts,omitempty"`
 }
 
 // ConflictState represents the current state of a single merge conflict as it is
 // store in mongo. This is embedded in the MergeState object as a ConflictMap.
 type ConflictState struct {
-	URL      string `bson:"url,omitempty" json:"url,omitempty"`
+	URL      string `bson:"url" json:"url"`
 	Resolved bool   `bson:"resolved" json:"resolved"`
 	Deleted  bool   `bson:"deleted" json:"deleted"`
 }


### PR DESCRIPTION
Once a merge conflict (OperationOutcome) is deleted it's URL should be unset since it's no longer a valid URL pointing to a FHIR resource.