### PR TITLE
Updated FHIR dependency to 1.8

### DIFF
--- a/fixtures/clint_abbot_bundle.json
+++ b/fixtures/clint_abbot_bundle.json
@@ -8,7 +8,7 @@
       	"resourceType": "Patient",
       	"id": "61ebe359-bfdc-4613-8bf2-c5e300945f2a",
       	"name": [{
-      		"family": ["Abbott"],
+      		"family": "Abbott",
       		"given": ["Clint"]
       	}],
       	"gender": "male",
@@ -183,7 +183,7 @@
       	"resourceType": "MedicationStatement",
       	"id": "61ebe359-bfdc-4613-8bf2-c5e300945f3b",
       	"status": "active",
-      	"patient": {
+      	"subject": {
       		"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f2a"
       	},
       	"effectivePeriod": {

--- a/fixtures/john_peters_bundle.json
+++ b/fixtures/john_peters_bundle.json
@@ -8,7 +8,7 @@
 				"resourceType": "Patient",
 				"id": "8374637118556222846",
 				"name": [{
-					"family": ["Peters"],
+					"family": "Peters",
 					"given": ["John"]
 				}],
 				"gender": "male",
@@ -374,7 +374,6 @@
 					"start": "2011-11-01T08:16:40-04:00",
 					"end": "2011-11-01T11:03:20-04:00"
 				},
-				"status": "final",
 				"subject": {
 					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
 				}
@@ -407,7 +406,6 @@
 					"start": "2011-11-01T08:16:40-04:00",
 					"end": "2011-11-01T11:03:20-04:00"
 				},
-				"status": "final",
 				"subject": {
 					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
 				}
@@ -440,7 +438,6 @@
 					"start": "2011-11-01T08:16:40-04:00",
 					"end": "2011-11-01T11:03:20-04:00"
 				},
-				"status": "final",
 				"subject": {
 					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
 				}
@@ -489,7 +486,7 @@
       "resource": {
 				"resourceType": "MedicationStatement",
 				"status": "completed",
-				"patient": {
+				"subject": {
 					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
 				},
 				"effectivePeriod": {

--- a/fixtures/one_conflict/clint_abbot_bundle_1.json
+++ b/fixtures/one_conflict/clint_abbot_bundle_1.json
@@ -8,7 +8,7 @@
       	"resourceType": "Patient",
       	"id": "61ebe359-bfdc-4613-8bf2-c5e300945f2a",
       	"name": [{
-      		"family": ["Abbott"],
+      		"family": "Abbott",
       		"given": ["Clint"]
       	}],
       	"gender": "male",
@@ -183,7 +183,7 @@
       	"resourceType": "MedicationStatement",
       	"id": "61ebe359-bfdc-4613-8bf2-c5e300945f3b",
       	"status": "active",
-      	"patient": {
+      	"subject": {
       		"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f2a"
       	},
       	"effectivePeriod": {

--- a/fixtures/one_conflict/clint_abbot_bundle_2.json
+++ b/fixtures/one_conflict/clint_abbot_bundle_2.json
@@ -8,7 +8,7 @@
       	"resourceType": "Patient",
       	"id": "61ebe359-bfdc-4613-8bf2-c5e300945f2a",
       	"name": [{
-      		"family": ["Abbott"],
+      		"family": "Abbott",
       		"given": ["Chip"]
       	}],
       	"gender": "male",
@@ -183,7 +183,7 @@
       	"resourceType": "MedicationStatement",
       	"id": "61ebe359-bfdc-4613-8bf2-c5e300945f3b",
       	"status": "active",
-      	"patient": {
+      	"subject": {
       		"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f2a"
       	},
       	"effectivePeriod": {

--- a/fixtures/two_conflicts/john_peters_bundle_1.json
+++ b/fixtures/two_conflicts/john_peters_bundle_1.json
@@ -8,7 +8,7 @@
 				"resourceType": "Patient",
 				"id": "8374637118556222846",
 				"name": [{
-					"family": ["Peters"],
+					"family": "Peters",
 					"given": ["John"]
 				}],
 				"gender": "male",
@@ -374,7 +374,6 @@
 					"start": "2011-11-01T08:16:40-04:00",
 					"end": "2011-11-01T11:03:20-04:00"
 				},
-				"status": "final",
 				"subject": {
 					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
 				}
@@ -407,7 +406,6 @@
 					"start": "2011-11-01T08:16:40-04:00",
 					"end": "2011-11-01T11:03:20-04:00"
 				},
-				"status": "final",
 				"subject": {
 					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
 				}
@@ -440,7 +438,6 @@
 					"start": "2011-11-01T08:16:40-04:00",
 					"end": "2011-11-01T11:03:20-04:00"
 				},
-				"status": "final",
 				"subject": {
 					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
 				}
@@ -489,7 +486,7 @@
       "resource": {
 				"resourceType": "MedicationStatement",
 				"status": "completed",
-				"patient": {
+				"subject": {
 					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
 				},
 				"effectivePeriod": {

--- a/fixtures/two_conflicts/john_peters_bundle_2.json
+++ b/fixtures/two_conflicts/john_peters_bundle_2.json
@@ -8,7 +8,7 @@
 				"resourceType": "Patient",
 				"id": "8374637118556222846",
 				"name": [{
-					"family": ["Peters"],
+					"family": "Peters",
 					"given": ["John"]
 				}],
 				"gender": "male",
@@ -270,7 +270,6 @@
 					"start": "2011-11-01T08:16:40-04:00",
 					"end": "2011-11-01T08:16:40-04:00"
 				},
-				"status": "final",
 				"subject": {
 					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
 				},
@@ -374,7 +373,6 @@
 					"start": "2011-11-01T08:16:40-04:00",
 					"end": "2011-11-01T11:03:20-04:00"
 				},
-				"status": "final",
 				"subject": {
 					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
 				}
@@ -407,7 +405,6 @@
 					"start": "2011-11-01T08:16:40-04:00",
 					"end": "2011-11-01T11:03:20-04:00"
 				},
-				"status": "final",
 				"subject": {
 					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
 				}
@@ -440,7 +437,6 @@
 					"start": "2011-11-01T08:16:40-04:00",
 					"end": "2011-11-01T11:03:20-04:00"
 				},
-				"status": "final",
 				"subject": {
 					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
 				}
@@ -489,7 +485,7 @@
       "resource": {
 				"resourceType": "MedicationStatement",
 				"status": "completed",
-				"patient": {
+				"subject": {
 					"reference": "urn:uuid:61ebe359-bfdc-4613-8bf2-c5e300945f0a"
 				},
 				"effectivePeriod": {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d21a0d7d2f549d87f4ac0db8e4f1d409b7c8e8203038dd74da687a50e652e2e0
-updated: 2017-01-26T13:12:03.119880116-05:00
+hash: f992d54e16eeeccddfde3064972c23693207712ecb31ae42f309db23cf33a071
+updated: 2017-02-09T09:55:14.269199169-05:00
 imports:
 - name: github.com/boj/redistore
   version: fc113767cd6b051980f260d6dbe84b2740c46ab0
@@ -34,7 +34,7 @@ imports:
 - name: github.com/icrowley/fake
   version: 84bff6d01560fb0b5a396ba29534e93fd00d09c6
 - name: github.com/intervention-engine/fhir
-  version: ffdbbf0fd38eef4edef052773901d71a5ff7a488
+  version: a4558c3caa99d393ae611d46e8c5037e86e0e9d8
   repo: https://github.com/intervention-engine/fhir.git
   vcs: git
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/gin-gonic/gin
 - package: github.com/intervention-engine/fhir
   vcs: git
-  version: stu3_aug2016
+  version: stu3_jan2017
   repo: https://github.com/intervention-engine/fhir.git
   subpackages:
   - models

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -139,7 +139,7 @@ func (s *ServerTestSuite) TestResolveConflictMergeNotFound() {
 		`{
 			"resourceType": "Patient",
 			"name": [{
-				"family": ["Abbott"],
+				"family": "Abbott",
 				"given": ["Clint"]
 			}],
 			"gender": "male",
@@ -188,7 +188,7 @@ func (s *ServerTestSuite) TestResolveConflictConflictNotFound() {
 		`{
 			"resourceType": "Patient",
 			"name": [{
-				"family": ["Abbott"],
+				"family": "Abbott",
 				"given": ["Clint"]
 			}],
 			"gender": "male",
@@ -235,7 +235,7 @@ func (s *ServerTestSuite) TestResolveConflictConflictAlreadyResolved() {
 		`{
 			"resourceType": "Patient",
 			"name": [{
-				"family": ["Abbott"],
+				"family": "Abbott",
 				"given": ["Clint"]
 			}],
 			"gender": "male",
@@ -287,7 +287,7 @@ func (s *ServerTestSuite) TestResolveConflictConflictAlreadyDeleted() {
 		`{
 			"resourceType": "Patient",
 			"name": [{
-				"family": ["Abbott"],
+				"family": "Abbott",
 				"given": ["Clint"]
 			}],
 			"gender": "male",


### PR DESCRIPTION
This broke a few tests primarily because the patient.name.family field changed from an array to a single string. All fixed now.