### PR TITLE
Matching Framework

### DIFF
--- a/fixtures/patients/foo_bar.json
+++ b/fixtures/patients/foo_bar.json
@@ -1,0 +1,10 @@
+{
+    "resourceType": "Patient",
+    "id": "61ebe359-bfdc-4613-8bf2-c5e300945f2a",
+    "name": [{
+        "family": "Bar",
+        "given": ["Foo"]
+    }],
+    "gender": "male",
+    "birthDate": "1960-04-05"
+}

--- a/merge/match_strategy.go
+++ b/merge/match_strategy.go
@@ -1,5 +1,0 @@
-package merge
-
-type MatchStrategy interface {
-	Match(left interface{}, right interface{}) (isMatch bool, err error)
-}

--- a/merge/matcher.go
+++ b/merge/matcher.go
@@ -1,7 +1,216 @@
 package merge
 
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/intervention-engine/fhir/models"
+)
+
+// MatchingStrategies maps a custom matching strategy to a specific resource type.
+// For example, "Patient": &PatientMatchingStrategy{}. To be used by Matcher.Match()
+// any new custom matching strategy must be registered here.
+var MatchingStrategies = map[string]MatchingStrategy{}
+
+// Matcher provides tools for identifying all resources in 2 source bundles that "match".
 type Matcher struct{}
 
-func (m *Matcher) Match(leftResources []interface{}, rightResources []interface{}, matchStrategy MatchStrategy) (matches []Match, noMatches []interface{}, err error) {
-	return
+// Match iterates through all resources in the two source bundles and attempts to find resources that "match". These
+// resources can then be compared to each other to see what conflicts may still exist between them. All matches are
+// returned as a slice of Match pairs. Resources without a match are returned separately as a slice of "unmatchables".
+func (m *Matcher) Match(leftBundle *models.Bundle, rightBundle *models.Bundle) (matches []Match, unmatchables []interface{}, err error) {
+
+	// First collect and separate out all resources we can or cannot match.
+	leftMatchables, leftUnmatchables, err := m.collectMatchableResources(leftBundle)
+	if err != nil {
+		return nil, nil, err
+	}
+	unmatchables = append(unmatchables, leftUnmatchables...)
+
+	rightMatchables, rightUnmatchables, err := m.collectMatchableResources(rightBundle)
+	if err != nil {
+		return nil, nil, err
+	}
+	unmatchables = append(unmatchables, rightUnmatchables...)
+
+	// There are now three sets to consider:
+	// 1. L intersect R - these are all the resource types we'll attempt to match
+	// 2. L not in R - these are "unmatchable" left resource types
+	// 3. R not in L - these are "unmatchable" right resource types
+	matchableResourceTypes := intersection(leftMatchables.Keys(), rightMatchables.Keys())
+	leftUnmatchableResourceTypes := setDiff(leftMatchables.Keys(), rightMatchables.Keys())  // L not in R
+	rightUnmatchableResourceTypes := setDiff(rightMatchables.Keys(), leftMatchables.Keys()) // R not in L
+
+	// Handle all of the unmatchable resource types.
+	for _, key := range leftUnmatchableResourceTypes {
+		unmatchables = append(unmatchables, leftMatchables[key]...)
+	}
+
+	for _, key := range rightUnmatchableResourceTypes {
+		unmatchables = append(unmatchables, rightMatchables[key]...)
+	}
+
+	// Handle all of the matchable resource types. Since the resourceType key existed
+	// in both the leftMatchables and rightMatchables, there is guaranteed to be at least
+	// one resource of each resourceType in both sets.
+	for _, resourceType := range matchableResourceTypes {
+		leftResources := leftMatchables[resourceType]
+		rightResources := rightMatchables[resourceType]
+
+		// Performs matching without replacement.
+		someMatches, someUnmatchables, err := m.matchWithoutReplacement(leftResources, rightResources, MatchingStrategies[resourceType])
+		if err != nil {
+			return nil, nil, err
+		}
+		matches = append(matches, someMatches...)
+		unmatchables = append(unmatchables, someUnmatchables...)
+	}
+	return matches, unmatchables, nil
+}
+
+// Processes all resources in a bundle and determines if they can be "matched". A resource can
+// only be matched if a MatchingStrategy is implemented and registered for its resource type.
+func (m *Matcher) collectMatchableResources(bundle *models.Bundle) (matchables ResourceMap, unmatchables []interface{}, err error) {
+	matchables = make(ResourceMap)
+
+	for _, entry := range bundle.Entry {
+		// Get the entry.Resource's type.
+		resourceType := getResourceType(entry.Resource)
+		// Make sure it's a known FHIR type.
+		s := models.StructForResourceName(resourceType)
+		if s == nil {
+			return nil, nil, fmt.Errorf("Unknown resource type %s", resourceType)
+		}
+
+		if m.supportsMatchingStrategyForResourceType(resourceType) {
+			matchables[resourceType] = append(matchables[resourceType], entry.Resource)
+		} else {
+			unmatchables = append(unmatchables, entry.Resource)
+		}
+	}
+	return matchables, unmatchables, nil
+}
+
+// Performs matching without replacement using the given strategy. If a match is found between a left resource and a
+// right resource, a new Match is created and the left and right are removed from their respective slices. Matching stops
+// when there are no elements remaining in one of the slices. The original slices are copied before being modified.
+func (m *Matcher) matchWithoutReplacement(left, right []interface{}, strategy MatchingStrategy) (matches []Match, unmatchables []interface{}, err error) {
+
+	// Make copies since these slices will be mutated.
+	leftResources := make([]interface{}, len(left))
+	copy(leftResources, left)
+	rightResources := make([]interface{}, len(right))
+	copy(rightResources, right)
+
+	for len(leftResources) > 0 {
+		// For consistency we always start with the first element in the left slice.
+		// Remove the resource from the front of the slice, then compare it to everything
+		// remaining in the right slice.
+		leftResource := leftResources[0]
+		leftResources = leftResources[1:]
+
+		matchFound := false
+		matchIdx := 0
+
+		for _, rightResource := range rightResources {
+			matchFound, err = strategy.Match(leftResource, rightResource)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			if matchFound {
+				matches = append(matches, Match{
+					Left:  leftResource,
+					Right: rightResource,
+				})
+				fmt.Println("new match: ", matches[len(matches)-1])
+				break
+			}
+
+			matchIdx++
+		}
+
+		if matchFound {
+			// Remove the rightResource from its slice.
+			rightResources = append(rightResources[:matchIdx], rightResources[matchIdx+1:]...)
+		} else {
+			// No match was found, so the leftResource has no match. Right resources remain unchanged.
+			unmatchables = append(unmatchables, leftResource)
+		}
+	}
+
+	// If there are any rightResources left, they're unmatchable.
+	if len(rightResources) > 0 {
+		unmatchables = append(unmatchables, rightResources...)
+	}
+
+	return matches, unmatchables, nil
+}
+
+// Returns true if a known matching strategy is implemented for the given resourceType.
+// All matching strategies should be registered in the MatchingStrategies map.
+func (m *Matcher) supportsMatchingStrategyForResourceType(resourceType string) bool {
+	for key := range MatchingStrategies {
+		if key == resourceType {
+			return true
+		}
+	}
+	return false
+}
+
+// ResourceMap is used to map a list of resources to their specific type.
+type ResourceMap map[string][]interface{}
+
+func (r ResourceMap) Keys() []string {
+	keys := make([]string, len(r))
+	i := 0
+	for k := range r {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
+func getResourceType(resource interface{}) string {
+	// For example, "*models.Patient"
+	typeWithPackage := reflect.TypeOf(resource).String()
+	// So split that part out.
+	parts := strings.Split(typeWithPackage, ".")
+	if len(parts) != 2 {
+		return ""
+	}
+	return parts[1]
+}
+
+// intersection returns all elements in left that are also in right.
+func intersection(left, right []string) []string {
+	both := []string{}
+	for _, el := range left {
+		if contains(right, el) {
+			both = append(both, el)
+		}
+	}
+	return both
+}
+
+// setDiff returns all elements in left that are NOT in right.
+func setDiff(left, right []string) []string {
+	diffs := []string{}
+	for _, el := range left {
+		if !contains(right, el) {
+			diffs = append(diffs, el)
+		}
+	}
+	return diffs
+}
+
+// contains tests if an element is in the set.
+func contains(set []string, el string) bool {
+	for _, item := range set {
+		if item == el {
+			return true
+		}
+	}
+	return false
 }

--- a/merge/matcher.go
+++ b/merge/matcher.go
@@ -124,7 +124,6 @@ func (m *Matcher) matchWithoutReplacement(left, right []interface{}, strategy Ma
 					Left:  leftResource,
 					Right: rightResource,
 				})
-				fmt.Println("new match: ", matches[len(matches)-1])
 				break
 			}
 

--- a/merge/matcher_test.go
+++ b/merge/matcher_test.go
@@ -1,0 +1,342 @@
+package merge
+
+import (
+	"testing"
+
+	"github.com/intervention-engine/fhir/models"
+	"github.com/mitre/ptmerge/testutil"
+	"github.com/stretchr/testify/suite"
+)
+
+type MatcherTestSuite struct {
+	suite.Suite
+}
+
+func TestMatcherTestSuite(t *testing.T) {
+	suite.Run(t, new(MatcherTestSuite))
+}
+
+// ========================================================================= //
+// MATCHING STRATEGY INTERFACE MOCKS                                         //
+// ========================================================================= //
+
+type FooType struct {
+	Value int
+}
+
+type FooMatchingStrategy struct{}
+
+func (f *FooMatchingStrategy) SupportedResourceType() string {
+	return "FooType"
+}
+
+func (f *FooMatchingStrategy) Match(left interface{}, right interface{}) (isMatch bool, err error) {
+	l := left.(*FooType)
+	r := right.(*FooType)
+	return l.Value == r.Value, nil
+}
+
+type BarType struct {
+	Value int
+}
+
+type BarMatchingStrategy struct{}
+
+func (f *BarMatchingStrategy) SupportedResourceType() string {
+	return "BarType"
+}
+
+func (f *BarMatchingStrategy) Match(left interface{}, right interface{}) (isMatch bool, err error) {
+	l := left.(*BarType)
+	r := right.(*BarType)
+	return l.Value == r.Value, nil
+}
+
+// ========================================================================= //
+// TEST MATCH                                                                //
+// ========================================================================= //
+
+func (m *MatcherTestSuite) TestMatch() {
+	fix1, err := testutil.LoadFixture("Bundle", "../fixtures/clint_abbot_bundle.json")
+	m.NoError(err)
+	m.NotNil(fix1)
+	bundle1, ok := fix1.(*models.Bundle)
+	m.True(ok)
+
+	fix2, err := testutil.LoadFixture("Bundle", "../fixtures/john_peters_bundle.json")
+	m.NoError(err)
+	m.NotNil(fix2)
+	bundle2, ok := fix2.(*models.Bundle)
+	m.True(ok)
+
+	matcher := new(Matcher)
+	matches, unmatchables, err := matcher.Match(bundle1, bundle2)
+	m.NoError(err)
+
+	// There are no MatchingStrategies implemented yet, so this should return the union
+	// of both bundles, left first.
+	m.Len(matches, 0)
+	m.Len(unmatchables, len(bundle1.Entry)+len(bundle2.Entry))
+	m.Equal(bundle1.Entry[0].Resource, unmatchables[0])
+}
+
+// ========================================================================= //
+// TEST PRIVATE METHODS                                                      //
+// ========================================================================= //
+
+func (m *MatcherTestSuite) TestSupportsMatchingStrategyForResourceType() {
+	MatchingStrategies["Foo"] = new(FooMatchingStrategy)
+	matcher := new(Matcher)
+	m.True(matcher.supportsMatchingStrategyForResourceType("Foo"))
+
+	delete(MatchingStrategies, "Foo")
+	m.False(matcher.supportsMatchingStrategyForResourceType("Foo"))
+}
+
+func (m *MatcherTestSuite) TestCollectMatchableResources() {
+	fix, err := testutil.LoadFixture("Bundle", "../fixtures/clint_abbot_bundle.json")
+	m.NoError(err)
+	m.NotNil(fix)
+	bundle, ok := fix.(*models.Bundle)
+	m.True(ok)
+	matcher := new(Matcher)
+	matchables, unmatchables, err := matcher.collectMatchableResources(bundle)
+	m.NoError(err)
+	// No custom matchers have been implemented yet, so everything should be "unmatchable".
+	m.NotNil(matchables)
+	m.Equal([]string{}, matchables.Keys())
+	m.NotNil(unmatchables)
+	m.Equal(len(bundle.Entry), len(unmatchables))
+}
+
+// ========================================================================= //
+// TEST MATCHING WITHOUT REPLACEMENT                                         //
+// ========================================================================= //
+
+func (m *MatcherTestSuite) TestOneLeftMatchesOneRightNoneRemaining() {
+	leftResources := []interface{}{
+		&FooType{Value: 1},
+	}
+	rightResources := []interface{}{
+		&FooType{Value: 1},
+	}
+
+	matcher := new(Matcher)
+	matches, unmatchables, err := matcher.matchWithoutReplacement(leftResources, rightResources, &FooMatchingStrategy{})
+
+	m.NoError(err)
+	m.Len(matches, 1)
+	m.Equal(Match{Left: leftResources[0], Right: rightResources[0]}, matches[0])
+
+	m.Len(unmatchables, 0)
+}
+
+func (m *MatcherTestSuite) TestOneLeftDoesntMatchOneRight() {
+	leftResources := []interface{}{
+		&FooType{Value: 1},
+	}
+	rightResources := []interface{}{
+		&FooType{Value: 2},
+	}
+
+	matcher := new(Matcher)
+	matches, unmatchables, err := matcher.matchWithoutReplacement(leftResources, rightResources, &FooMatchingStrategy{})
+
+	m.NoError(err)
+	m.Len(matches, 0)
+
+	m.Len(unmatchables, 2)
+	m.Equal(append(leftResources, rightResources...), unmatchables)
+}
+
+func (m *MatcherTestSuite) TestOneLeftMatchesOneRightRightsRemaining() {
+	leftResources := []interface{}{
+		&FooType{Value: 1},
+	}
+	rightResources := []interface{}{
+		&FooType{Value: 0},
+		&FooType{Value: 1},
+		&FooType{Value: 2},
+	}
+
+	matcher := new(Matcher)
+	matches, unmatchables, err := matcher.matchWithoutReplacement(leftResources, rightResources, &FooMatchingStrategy{})
+
+	m.NoError(err)
+	m.Len(matches, 1)
+	m.Equal(Match{Left: leftResources[0], Right: rightResources[1]}, matches[0])
+
+	m.Len(unmatchables, 2)
+	m.Equal([]interface{}{rightResources[0], rightResources[2]}, unmatchables)
+}
+
+func (m *MatcherTestSuite) TestOneLeftMatchesOneRightLeftsRemaining() {
+	leftResources := []interface{}{
+		&FooType{Value: 3},
+		&FooType{Value: 2},
+		&FooType{Value: 1},
+	}
+	rightResources := []interface{}{
+		&FooType{Value: 1},
+	}
+
+	matcher := new(Matcher)
+	matches, unmatchables, err := matcher.matchWithoutReplacement(leftResources, rightResources, &FooMatchingStrategy{})
+
+	m.NoError(err)
+	m.Len(matches, 1)
+	m.Equal(Match{Left: leftResources[2], Right: rightResources[0]}, matches[0])
+
+	m.Len(unmatchables, 2)
+	m.Equal(leftResources[:2], unmatchables)
+}
+
+func (m *MatcherTestSuite) TestMultipleMatchesRightsRemaining() {
+	leftResources := []interface{}{
+		&FooType{Value: 1},
+		&FooType{Value: 4},
+	}
+	rightResources := []interface{}{
+		&FooType{Value: 1},
+		&FooType{Value: 4},
+		&FooType{Value: 7},
+		&FooType{Value: 8},
+	}
+
+	matcher := new(Matcher)
+	matches, unmatchables, err := matcher.matchWithoutReplacement(leftResources, rightResources, &FooMatchingStrategy{})
+
+	m.NoError(err)
+	m.Len(matches, 2)
+	m.Equal(Match{Left: leftResources[0], Right: rightResources[0]}, matches[0])
+	m.Equal(Match{Left: leftResources[1], Right: rightResources[1]}, matches[1])
+
+	m.Len(unmatchables, 2)
+	m.Equal(rightResources[2:], unmatchables)
+}
+
+func (m *MatcherTestSuite) TestMultipleMatchesLeftsRemaining() {
+	leftResources := []interface{}{
+		&FooType{Value: 1},
+		&FooType{Value: 2},
+		&FooType{Value: 3},
+		&FooType{Value: 4},
+	}
+	rightResources := []interface{}{
+		&FooType{Value: 2},
+		&FooType{Value: 3},
+	}
+
+	matcher := new(Matcher)
+	matches, unmatchables, err := matcher.matchWithoutReplacement(leftResources, rightResources, &FooMatchingStrategy{})
+
+	m.NoError(err)
+	m.Len(matches, 2)
+	m.Equal(Match{Left: leftResources[1], Right: rightResources[0]}, matches[0])
+	m.Equal(Match{Left: leftResources[2], Right: rightResources[1]}, matches[1])
+
+	m.Len(unmatchables, 2)
+	m.Equal([]interface{}{leftResources[0], leftResources[3]}, unmatchables)
+}
+
+func (m *MatcherTestSuite) TestMultipleMatchesBothRemaining() {
+	leftResources := []interface{}{
+		&FooType{Value: 1},
+		&FooType{Value: 2},
+		&FooType{Value: 4},
+		&FooType{Value: 3},
+	}
+	rightResources := []interface{}{
+		&FooType{Value: 5},
+		&FooType{Value: 2},
+		&FooType{Value: 6},
+		&FooType{Value: 3},
+	}
+
+	matcher := new(Matcher)
+	matches, unmatchables, err := matcher.matchWithoutReplacement(leftResources, rightResources, &FooMatchingStrategy{})
+
+	m.NoError(err)
+	m.Len(matches, 2)
+	m.Equal(Match{Left: leftResources[1], Right: rightResources[1]}, matches[0])
+	m.Equal(Match{Left: leftResources[3], Right: rightResources[3]}, matches[1])
+
+	m.Len(unmatchables, 4)
+	m.Equal([]interface{}{leftResources[0], leftResources[2], rightResources[0], rightResources[2]}, unmatchables)
+}
+
+func (m *MatcherTestSuite) TestMultipleMatchesOrderOfPreference() {
+	// Since we always start with the next left first,
+	// the order of the unmatchables should be deterministic.
+	leftResources := []interface{}{
+		&FooType{Value: 1},
+		&FooType{Value: 2},
+	}
+	rightResources := []interface{}{
+		&FooType{Value: 0},
+		&FooType{Value: 2}, // should specifically match this one
+		&FooType{Value: 2},
+	}
+
+	matcher := new(Matcher)
+	matches, unmatchables, err := matcher.matchWithoutReplacement(leftResources, rightResources, &FooMatchingStrategy{})
+
+	m.NoError(err)
+	m.Len(matches, 1)
+	m.Equal(Match{Left: leftResources[1], Right: rightResources[1]}, matches[0])
+
+	m.Len(unmatchables, 3)
+	m.Equal([]interface{}{leftResources[0], rightResources[0], rightResources[2]}, unmatchables)
+}
+
+// ========================================================================= //
+// TEST SUPPORTING FUNCTIONS                                                 //
+// ========================================================================= //
+
+func (m *MatcherTestSuite) TestGetResourceType() {
+	test, err := testutil.LoadFixture("Patient", "../fixtures/patients/foo_bar.json")
+	m.NoError(err)
+	typeAsString := getResourceType(test)
+	m.Equal("Patient", typeAsString)
+}
+
+func (m *MatcherTestSuite) TestResourceMapKeys() {
+	rm := make(ResourceMap)
+	rm["foo"] = []interface{}{1}
+	rm["bar"] = []interface{}{1, 2}
+	rm["hey"] = []interface{}{1, 2, 3}
+
+	expected := []string{"foo", "bar", "hey"} // Not necessarily in this order
+	keys := rm.Keys()
+	for _, k := range keys {
+		m.True(contains(expected, k))
+	}
+}
+
+// ========================================================================= //
+// TEST SET FUNCTIONS                                                        //
+// ========================================================================= //
+
+func (m *MatcherTestSuite) TestSetIntersection() {
+	left := []string{"a", "b", "c"}
+	right := []string{"b", "c", "d"}
+
+	ints := intersection(left, right)
+	m.Equal([]string{"b", "c"}, ints)
+}
+
+func (m *MatcherTestSuite) TestSetDiff() {
+	left := []string{"a", "b", "c"}
+	right := []string{"b", "c", "d"}
+
+	lDiffs := setDiff(left, right)
+	m.Equal([]string{"a"}, lDiffs)
+
+	rDiffs := setDiff(right, left)
+	m.Equal([]string{"d"}, rDiffs)
+}
+
+func (m *MatcherTestSuite) TestSetContains() {
+	set := []string{"a", "b", "c"}
+	m.True(contains(set, "b"))
+}

--- a/merge/matching_strategy.go
+++ b/merge/matching_strategy.go
@@ -1,0 +1,8 @@
+package merge
+
+type MatchingStrategy interface {
+	// SupportedResourceType returns the name of the resource that this strategy supports.
+	SupportedResourceType() string
+	// Match returns true if the left resource matches the right resource.
+	Match(left interface{}, right interface{}) (isMatch bool, err error)
+}

--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -77,6 +78,20 @@ func PostFixture(fhirHost, resourceName, fixturePath string) (res *http.Response
 		return nil, err
 	}
 	return res, nil
+}
+
+// LoadFixture returns a resource-appropriate struct for the unmarshaled fixture.
+func LoadFixture(resourceName, fixturePath string) (resource interface{}, err error) {
+	data, err := ioutil.ReadFile(fixturePath)
+	resourceStruct := models.NewStructForResourceName(resourceName)
+	if resourceStruct == nil {
+		return nil, fmt.Errorf("Unknown resource type '%s'", resourceName)
+	}
+	err = json.Unmarshal(data, &resourceStruct)
+	if err != nil {
+		return nil, err
+	}
+	return resourceStruct, nil
 }
 
 // CreateMockConflictBundle creates a sample Bundle with n OperationOutcomes

--- a/testutil/helpers_test.go
+++ b/testutil/helpers_test.go
@@ -1,0 +1,27 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/intervention-engine/fhir/models"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestutilTestSuite struct {
+	suite.Suite
+}
+
+func TestTestutilTestSuite(t *testing.T) {
+	suite.Run(t, new(TestutilTestSuite))
+}
+
+func (m *TestutilTestSuite) TestLoadFixture() {
+	fix, err := LoadFixture("Patient", "../fixtures/patients/foo_bar.json")
+	m.NoError(err)
+	patient, ok := fix.(*models.Patient)
+	m.True(ok)
+	m.Len(patient.Name, 1)
+	m.Len(patient.Name[0].Given, 1)
+	m.Equal("Foo", patient.Name[0].Given[0])
+	m.Equal("Bar", patient.Name[0].Family)
+}


### PR DESCRIPTION
Added the generic matching framework (not to be confused with Synthea's GMF 😉 ) and supporting unit tests. Additional tests of Matcher.Match() will need to be written once some MatchingStrategies have been developed.

To satisfy my OCD-ness I renamed `MatchStrategy` to `MatchingStrategy`. Any strategies that implement this should be of the form `<Resource>MatchingStrategy`. It just reads nicer.