### PR TITLE
Conflict Detection Framework

### DIFF
--- a/merge/conflict_detector.go
+++ b/merge/conflict_detector.go
@@ -1,9 +1,130 @@
 package merge
 
-import "github.com/intervention-engine/fhir/models"
+import (
+	"fmt"
+	"reflect"
+	"strings"
 
-type ConflictDetector struct{}
+	"gopkg.in/mgo.v2/bson"
 
-func (c *ConflictDetector) Conflicts(match Match, conflictStrategy ConflictStrategy) (conflict *models.OperationOutcome, err error) {
-	return
+	"github.com/intervention-engine/fhir/models"
+)
+
+// ConflictStrategies maps a custom conflict detection strategy to a specific resource type.
+// For example, "Patient": &PatientConflictStrategy{}. To be used by Detector.FindConflicts()
+// any new custom conflict detection strategy must be registered here.
+var ConflictStrategies = map[string]ConflictStrategy{}
+
+// Detector provides tools for identifying all conflicts between 2 resources in a Match.
+type Detector struct{}
+
+// FindConflicts identifies all conflicts between a set of Matches, returning an OperationOutcome for
+// each match detailing the location(s) of conflicts between the resources in the Match.
+func (d *Detector) FindConflicts(matches []Match) (conflicts []models.OperationOutcome, err error) {
+
+	// First, iterate through all of the matches to determine what conflicts, if any exist.
+	for _, match := range matches {
+		strategy, ok := ConflictStrategies[match.ResourceType]
+		if !ok {
+			// No known conflict strategy exists for this resource type. To be safe, we mark every
+			// non-nil field in either resource as a conflict and leave it up to the user to resolve them.
+			locations := []string{}
+			value := reflect.ValueOf(match.Left)
+			traverse(&locations, value, value.Type().Name())
+			conflicts = append(conflicts, *createConflictOperationOutcome(locations))
+			continue
+		}
+
+		locations, err := strategy.FindConflicts(match)
+		if err != nil {
+			return nil, err
+		}
+
+		// If there is no error and locations is empty, then the match was a "perfect" match, with no conflicts.
+		if len(locations) > 0 {
+			conflicts = append(conflicts, *createConflictOperationOutcome(locations))
+		}
+	}
+	return conflicts, nil
+}
+
+// traverse recursively iterates through all non-nil fields in the resource, identifying the JSON paths
+// to the non-nil fields. These paths are then used to identify the location of any conflicts.
+func traverse(paths *[]string, value reflect.Value, path string) {
+	switch value.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		// To get the actual value of the object or interface being pointed to we use Elem().
+		val := value.Elem()
+		// Check if the pointer or interface is nil.
+		if !val.IsValid() {
+			return
+		}
+		// Traverse the object that's being pointed to.
+		traverse(paths, val, path)
+
+	case reflect.Struct:
+		// We don't traverse into time objects.
+		if value.Type().Name() == "Time" {
+			*paths = append(*paths, path)
+			return
+		}
+
+		// Traverse all non-nil fields in the struct, building up their json paths.
+		for i := 0; i < value.NumField(); i++ {
+			jsonPath := value.Type().Field(i).Tag.Get("json")
+			// jsonPath will be empty for inline resourced (e.g. DomainResource).
+			if jsonPath != "" {
+				prefix := ""
+				// The path is empty if we're currently traversing the top-level object (e.g. Patient).
+				if path != "" {
+					prefix = path + "."
+				}
+				// Splits into the name of the field (e.g. "gender") and the "omitempty" flag.
+				parts := strings.SplitN(jsonPath, ",", 2)
+				traverse(paths, value.Field(i), prefix+parts[0])
+			} else {
+				// This was an inline resource, so we shouldn't add it to the path. Just traverse
+				// it's fields instead.
+				traverse(paths, value.Field(i), path)
+			}
+		}
+
+	case reflect.Slice:
+		// Traverse all elements in the slice.
+		for i := 0; i < value.Len(); i++ {
+			traverse(paths, value.Index(i), path+fmt.Sprintf("[%d]", i))
+		}
+
+	case reflect.String:
+		// Check that the string isn't nil.
+		val := value.String()
+		if val != "" {
+			*paths = append(*paths, path)
+		}
+
+	default:
+		// These are all of the other primitive types (e.g. int, float, bool).
+		*paths = append(*paths, path)
+	}
+}
+
+func createConflictOperationOutcome(locations []string) *models.OperationOutcome {
+	outcome := &models.OperationOutcome{
+		DomainResource: models.DomainResource{
+			Resource: models.Resource{
+				Id:           bson.NewObjectId().Hex(),
+				ResourceType: "OperationOutcome",
+			},
+		},
+		Issue: []models.OperationOutcomeIssueComponent{
+			models.OperationOutcomeIssueComponent{
+				Severity:    "information",
+				Code:        "conflict",
+				Location:    locations,
+				Diagnostics: "",
+			},
+		},
+	}
+
+	return outcome
 }

--- a/merge/conflict_detector.go
+++ b/merge/conflict_detector.go
@@ -1,114 +1,69 @@
 package merge
 
 import (
-	"fmt"
 	"reflect"
-	"strings"
 
 	"gopkg.in/mgo.v2/bson"
 
 	"github.com/intervention-engine/fhir/models"
 )
 
-// ConflictStrategies maps a custom conflict detection strategy to a specific resource type.
-// For example, "Patient": &PatientConflictStrategy{}. To be used by Detector.FindConflicts()
-// any new custom conflict detection strategy must be registered here.
-var ConflictStrategies = map[string]ConflictStrategy{}
-
-// Detector provides tools for identifying all conflicts between 2 resources in a Match.
+// Detector provides tools for detecting all conflicts between 2 resources in a Match.
 type Detector struct{}
 
-// FindConflicts identifies all conflicts between a set of Matches, returning an OperationOutcome for
+// AllConflicts identifies all conflicts between a set of Matches, returning an OperationOutcome for
 // each match detailing the location(s) of conflicts between the resources in the Match.
-func (d *Detector) FindConflicts(matches []Match) (conflicts []models.OperationOutcome, err error) {
-
-	// First, iterate through all of the matches to determine what conflicts, if any exist.
+func (d *Detector) AllConflicts(matches []Match) (conflicts []models.OperationOutcome, err error) {
 	for _, match := range matches {
-		strategy, ok := ConflictStrategies[match.ResourceType]
-		if !ok {
-			// No known conflict strategy exists for this resource type. To be safe, we mark every
-			// non-nil field in either resource as a conflict and leave it up to the user to resolve them.
-			locations := []string{}
-			value := reflect.ValueOf(match.Left)
-			traverse(&locations, value, value.Type().Name())
-			conflicts = append(conflicts, *createConflictOperationOutcome(locations))
-			continue
-		}
-
-		locations, err := strategy.FindConflicts(match)
+		conflict, err := d.findConflicts(&match)
 		if err != nil {
 			return nil, err
 		}
-
-		// If there is no error and locations is empty, then the match was a "perfect" match, with no conflicts.
-		if len(locations) > 0 {
-			conflicts = append(conflicts, *createConflictOperationOutcome(locations))
+		if conflict != nil {
+			conflicts = append(conflicts, *conflict)
 		}
 	}
 	return conflicts, nil
 }
 
-// traverse recursively iterates through all non-nil fields in the resource, identifying the JSON paths
-// to the non-nil fields. These paths are then used to identify the location of any conflicts.
-func traverse(paths *[]string, value reflect.Value, path string) {
-	switch value.Kind() {
-	case reflect.Ptr, reflect.Interface:
-		// To get the actual value of the object or interface being pointed to we use Elem().
-		val := value.Elem()
-		// Check if the pointer or interface is nil.
-		if !val.IsValid() {
-			return
-		}
-		// Traverse the object that's being pointed to.
-		traverse(paths, val, path)
+func (d *Detector) findConflicts(match *Match) (conflict *models.OperationOutcome, err error) {
+	// First, find all non-nil paths in the left resource, and the values at those paths.
+	leftPaths := make(PathMap)
+	traverse(reflect.ValueOf(match.Left), leftPaths, "")
 
-	case reflect.Struct:
-		// We don't traverse into time objects.
-		if value.Type().Name() == "Time" {
-			*paths = append(*paths, path)
-			return
-		}
+	// Then traverse the right.
+	rightPaths := make(PathMap)
+	traverse(reflect.ValueOf(match.Right), rightPaths, "")
 
-		// Traverse all non-nil fields in the struct, building up their json paths.
-		for i := 0; i < value.NumField(); i++ {
-			jsonPath := value.Type().Field(i).Tag.Get("json")
-			// jsonPath will be empty for inline resourced (e.g. DomainResource).
-			if jsonPath != "" {
-				prefix := ""
-				// The path is empty if we're currently traversing the top-level object (e.g. Patient).
-				if path != "" {
-					prefix = path + "."
-				}
-				// Splits into the name of the field (e.g. "gender") and the "omitempty" flag.
-				parts := strings.SplitN(jsonPath, ",", 2)
-				traverse(paths, value.Field(i), prefix+parts[0])
-			} else {
-				// This was an inline resource, so we shouldn't add it to the path. Just traverse
-				// it's fields instead.
-				traverse(paths, value.Field(i), path)
-			}
-		}
+	// Finally, compare paths and values. If a path exists in both resources we can compare
+	// it to identify conflicts. If it only exists in one resource, there is automatically a conflict.
+	commonPaths := intersection(leftPaths.Keys(), rightPaths.Keys())
+	leftOnlyPaths := setDiff(leftPaths.Keys(), rightPaths.Keys())  // L not in R
+	rightOnlyPaths := setDiff(rightPaths.Keys(), leftPaths.Keys()) // R not in L
 
-	case reflect.Slice:
-		// Traverse all elements in the slice.
-		for i := 0; i < value.Len(); i++ {
-			traverse(paths, value.Index(i), path+fmt.Sprintf("[%d]", i))
-		}
+	// Find conflicts between the common paths.
+	locations := []string{}
 
-	case reflect.String:
-		// Check that the string isn't nil.
-		val := value.String()
-		if val != "" {
-			*paths = append(*paths, path)
+	for _, cp := range commonPaths {
+		// Unless the values are EXACTLY the same, we mark them as a conflict.
+		if !compareValues(leftPaths[cp], rightPaths[cp]) {
+			locations = append(locations, cp)
 		}
-
-	default:
-		// These are all of the other primitive types (e.g. int, float, bool).
-		*paths = append(*paths, path)
 	}
+
+	// Left-only and right-only paths are automatically conflicts.
+	locations = append(locations, leftOnlyPaths...)
+	locations = append(locations, rightOnlyPaths...)
+
+	// Build a new OperationOutcome detailing all conflicts for this match.
+	if len(locations) > 0 {
+		return d.createConflictOperationOutcome(locations), nil
+	}
+	// No conflicts found
+	return nil, nil
 }
 
-func createConflictOperationOutcome(locations []string) *models.OperationOutcome {
+func (d *Detector) createConflictOperationOutcome(locations []string) *models.OperationOutcome {
 	outcome := &models.OperationOutcome{
 		DomainResource: models.DomainResource{
 			Resource: models.Resource{
@@ -118,10 +73,9 @@ func createConflictOperationOutcome(locations []string) *models.OperationOutcome
 		},
 		Issue: []models.OperationOutcomeIssueComponent{
 			models.OperationOutcomeIssueComponent{
-				Severity:    "information",
-				Code:        "conflict",
-				Location:    locations,
-				Diagnostics: "",
+				Severity: "information",
+				Code:     "conflict",
+				Location: locations,
 			},
 		},
 	}

--- a/merge/conflict_detector_test.go
+++ b/merge/conflict_detector_test.go
@@ -1,0 +1,91 @@
+package merge
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/intervention-engine/fhir/models"
+	"github.com/stretchr/testify/suite"
+)
+
+type DetectorTestSuite struct {
+	suite.Suite
+}
+
+func TestDetectorTestSuite(t *testing.T) {
+	suite.Run(t, new(DetectorTestSuite))
+}
+
+// ========================================================================= //
+// STRUCT TRAVERSAL                                                          //
+// ========================================================================= //
+
+func (d *DetectorTestSuite) TestStructTraversal() {
+	deceased := false
+	// Zero value pointers and strings are ignored, but zero numeric values should
+	// be preserved. The three major "zero" types are covered in this example:
+	// 1. nil pointers
+	// 2. empty strings
+	// 3. numeric values of 0
+	patient := &models.Patient{
+		Name: []models.HumanName{
+			models.HumanName{
+				Family: "Mercury",
+				Given:  []string{"Freddy"},
+			},
+		},
+		Gender:          "Male",
+		DeceasedBoolean: &deceased,
+		MaritalStatus: &models.CodeableConcept{
+			Coding: []models.Coding{
+				models.Coding{
+					System:  "http://hl7.org/fhir/v3/MaritalStatus",
+					Code:    "M",
+					Display: "Married",
+				},
+			},
+		},
+		Address: []models.Address{
+			models.Address{
+				Line:    []string{"1 London Way"},
+				City:    "London",
+				Country: "UK",
+			},
+		},
+		BirthDate: &models.FHIRDateTime{
+			// We don't traverse into time objects, so there will only be one path here
+			Time: time.Now(),
+		},
+	}
+
+	// Adding a contained quantity object to test the handling of zero-value numeric types.
+	quantity := float64(0)
+	patient.Contained = []interface{}{
+		models.Quantity{
+			Value: &quantity,
+			Unit:  "Songs",
+		},
+	}
+
+	paths := []string{}
+	// The order is deterministic. We expect these fields to be non-nil
+	// in the JSON equivalent of this patient object.
+	expected := []string{
+		"contained[0].value",
+		"contained[0].unit",
+		"name[0].family",
+		"name[0].given[0]",
+		"gender", "birthDate",
+		"deceasedBoolean",
+		"address[0].line[0]",
+		"address[0].city",
+		"address[0].country",
+		"maritalStatus.coding[0].system",
+		"maritalStatus.coding[0].code",
+		"maritalStatus.coding[0].display",
+	}
+	value := reflect.ValueOf(*patient)
+	traverse(&paths, value, "")
+	d.Equal(expected, paths)
+}

--- a/merge/conflict_strategy.go
+++ b/merge/conflict_strategy.go
@@ -1,8 +1,0 @@
-package merge
-
-type ConflictStrategy interface {
-	// SupportedResourceType returns the name of the resource that this strategy supports.
-	SupportedResourceType() string
-	// FindConflicts a slice of conflict locations between the two resources in a Match.
-	FindConflicts(match Match) (locations []string, err error)
-}

--- a/merge/conflict_strategy.go
+++ b/merge/conflict_strategy.go
@@ -1,5 +1,8 @@
 package merge
 
 type ConflictStrategy interface {
-	Conflicts(left interface{}, right interface{}) (locations []string, err error)
+	// SupportedResourceType returns the name of the resource that this strategy supports.
+	SupportedResourceType() string
+	// FindConflicts a slice of conflict locations between the two resources in a Match.
+	FindConflicts(match Match) (locations []string, err error)
 }

--- a/merge/match.go
+++ b/merge/match.go
@@ -1,9 +1,0 @@
-package merge
-
-// Match pairs up to FHIR resources that "match". These resources should be of the same
-// resource type (e.g. Patient).
-type Match struct {
-	ResourceType string
-	Left         interface{}
-	Right        interface{}
-}

--- a/merge/match.go
+++ b/merge/match.go
@@ -1,6 +1,9 @@
 package merge
 
+// Match pairs up to FHIR resources that "match". These resources should be of the same
+// resource type (e.g. Patient).
 type Match struct {
-	Left  interface{}
-	Right interface{}
+	ResourceType string
+	Left         interface{}
+	Right        interface{}
 }

--- a/merge/matcher.go
+++ b/merge/matcher.go
@@ -121,8 +121,9 @@ func (m *Matcher) matchWithoutReplacement(left, right []interface{}, strategy Ma
 
 			if matchFound {
 				matches = append(matches, Match{
-					Left:  leftResource,
-					Right: rightResource,
+					ResourceType: strategy.SupportedResourceType(),
+					Left:         leftResource,
+					Right:        rightResource,
 				})
 				break
 			}

--- a/merge/matcher.go
+++ b/merge/matcher.go
@@ -2,8 +2,6 @@ package merge
 
 import (
 	"fmt"
-	"reflect"
-	"strings"
 
 	"github.com/intervention-engine/fhir/models"
 )
@@ -153,62 +151,6 @@ func (m *Matcher) matchWithoutReplacement(left, right []interface{}, strategy Ma
 func (m *Matcher) supportsMatchingStrategyForResourceType(resourceType string) bool {
 	for key := range MatchingStrategies {
 		if key == resourceType {
-			return true
-		}
-	}
-	return false
-}
-
-// ResourceMap is used to map a list of resources to their specific type.
-type ResourceMap map[string][]interface{}
-
-func (r ResourceMap) Keys() []string {
-	keys := make([]string, len(r))
-	i := 0
-	for k := range r {
-		keys[i] = k
-		i++
-	}
-	return keys
-}
-
-func getResourceType(resource interface{}) string {
-	// For example, "*models.Patient"
-	typeWithPackage := reflect.TypeOf(resource).String()
-	// So split that part out.
-	parts := strings.Split(typeWithPackage, ".")
-	if len(parts) != 2 {
-		return ""
-	}
-	return parts[1]
-}
-
-// intersection returns all elements in left that are also in right.
-func intersection(left, right []string) []string {
-	both := []string{}
-	for _, el := range left {
-		if contains(right, el) {
-			both = append(both, el)
-		}
-	}
-	return both
-}
-
-// setDiff returns all elements in left that are NOT in right.
-func setDiff(left, right []string) []string {
-	diffs := []string{}
-	for _, el := range left {
-		if !contains(right, el) {
-			diffs = append(diffs, el)
-		}
-	}
-	return diffs
-}
-
-// contains tests if an element is in the set.
-func contains(set []string, el string) bool {
-	for _, item := range set {
-		if item == el {
 			return true
 		}
 	}

--- a/merge/matcher_test.go
+++ b/merge/matcher_test.go
@@ -36,22 +36,6 @@ func (f *FooMatchingStrategy) Match(left interface{}, right interface{}) (isMatc
 	return l.Value == r.Value, nil
 }
 
-type BarType struct {
-	Value int
-}
-
-type BarMatchingStrategy struct{}
-
-func (f *BarMatchingStrategy) SupportedResourceType() string {
-	return "BarType"
-}
-
-func (f *BarMatchingStrategy) Match(left interface{}, right interface{}) (isMatch bool, err error) {
-	l := left.(*BarType)
-	r := right.(*BarType)
-	return l.Value == r.Value, nil
-}
-
 // ========================================================================= //
 // TEST MATCH                                                                //
 // ========================================================================= //
@@ -287,56 +271,4 @@ func (m *MatcherTestSuite) TestMultipleMatchesOrderOfPreference() {
 
 	m.Len(unmatchables, 3)
 	m.Equal([]interface{}{leftResources[0], rightResources[0], rightResources[2]}, unmatchables)
-}
-
-// ========================================================================= //
-// TEST SUPPORTING FUNCTIONS                                                 //
-// ========================================================================= //
-
-func (m *MatcherTestSuite) TestGetResourceType() {
-	test, err := testutil.LoadFixture("Patient", "../fixtures/patients/foo_bar.json")
-	m.NoError(err)
-	typeAsString := getResourceType(test)
-	m.Equal("Patient", typeAsString)
-}
-
-func (m *MatcherTestSuite) TestResourceMapKeys() {
-	rm := make(ResourceMap)
-	rm["foo"] = []interface{}{1}
-	rm["bar"] = []interface{}{1, 2}
-	rm["hey"] = []interface{}{1, 2, 3}
-
-	expected := []string{"foo", "bar", "hey"} // Not necessarily in this order
-	keys := rm.Keys()
-	for _, k := range keys {
-		m.True(contains(expected, k))
-	}
-}
-
-// ========================================================================= //
-// TEST SET FUNCTIONS                                                        //
-// ========================================================================= //
-
-func (m *MatcherTestSuite) TestSetIntersection() {
-	left := []string{"a", "b", "c"}
-	right := []string{"b", "c", "d"}
-
-	ints := intersection(left, right)
-	m.Equal([]string{"b", "c"}, ints)
-}
-
-func (m *MatcherTestSuite) TestSetDiff() {
-	left := []string{"a", "b", "c"}
-	right := []string{"b", "c", "d"}
-
-	lDiffs := setDiff(left, right)
-	m.Equal([]string{"a"}, lDiffs)
-
-	rDiffs := setDiff(right, left)
-	m.Equal([]string{"d"}, rDiffs)
-}
-
-func (m *MatcherTestSuite) TestSetContains() {
-	set := []string{"a", "b", "c"}
-	m.True(contains(set, "b"))
 }

--- a/merge/matcher_test.go
+++ b/merge/matcher_test.go
@@ -126,7 +126,7 @@ func (m *MatcherTestSuite) TestOneLeftMatchesOneRightNoneRemaining() {
 
 	m.NoError(err)
 	m.Len(matches, 1)
-	m.Equal(Match{Left: leftResources[0], Right: rightResources[0]}, matches[0])
+	m.Equal(Match{ResourceType: "FooType", Left: leftResources[0], Right: rightResources[0]}, matches[0])
 
 	m.Len(unmatchables, 0)
 }
@@ -164,7 +164,7 @@ func (m *MatcherTestSuite) TestOneLeftMatchesOneRightRightsRemaining() {
 
 	m.NoError(err)
 	m.Len(matches, 1)
-	m.Equal(Match{Left: leftResources[0], Right: rightResources[1]}, matches[0])
+	m.Equal(Match{ResourceType: "FooType", Left: leftResources[0], Right: rightResources[1]}, matches[0])
 
 	m.Len(unmatchables, 2)
 	m.Equal([]interface{}{rightResources[0], rightResources[2]}, unmatchables)
@@ -185,7 +185,7 @@ func (m *MatcherTestSuite) TestOneLeftMatchesOneRightLeftsRemaining() {
 
 	m.NoError(err)
 	m.Len(matches, 1)
-	m.Equal(Match{Left: leftResources[2], Right: rightResources[0]}, matches[0])
+	m.Equal(Match{ResourceType: "FooType", Left: leftResources[2], Right: rightResources[0]}, matches[0])
 
 	m.Len(unmatchables, 2)
 	m.Equal(leftResources[:2], unmatchables)
@@ -208,8 +208,8 @@ func (m *MatcherTestSuite) TestMultipleMatchesRightsRemaining() {
 
 	m.NoError(err)
 	m.Len(matches, 2)
-	m.Equal(Match{Left: leftResources[0], Right: rightResources[0]}, matches[0])
-	m.Equal(Match{Left: leftResources[1], Right: rightResources[1]}, matches[1])
+	m.Equal(Match{ResourceType: "FooType", Left: leftResources[0], Right: rightResources[0]}, matches[0])
+	m.Equal(Match{ResourceType: "FooType", Left: leftResources[1], Right: rightResources[1]}, matches[1])
 
 	m.Len(unmatchables, 2)
 	m.Equal(rightResources[2:], unmatchables)
@@ -232,8 +232,8 @@ func (m *MatcherTestSuite) TestMultipleMatchesLeftsRemaining() {
 
 	m.NoError(err)
 	m.Len(matches, 2)
-	m.Equal(Match{Left: leftResources[1], Right: rightResources[0]}, matches[0])
-	m.Equal(Match{Left: leftResources[2], Right: rightResources[1]}, matches[1])
+	m.Equal(Match{ResourceType: "FooType", Left: leftResources[1], Right: rightResources[0]}, matches[0])
+	m.Equal(Match{ResourceType: "FooType", Left: leftResources[2], Right: rightResources[1]}, matches[1])
 
 	m.Len(unmatchables, 2)
 	m.Equal([]interface{}{leftResources[0], leftResources[3]}, unmatchables)
@@ -258,8 +258,8 @@ func (m *MatcherTestSuite) TestMultipleMatchesBothRemaining() {
 
 	m.NoError(err)
 	m.Len(matches, 2)
-	m.Equal(Match{Left: leftResources[1], Right: rightResources[1]}, matches[0])
-	m.Equal(Match{Left: leftResources[3], Right: rightResources[3]}, matches[1])
+	m.Equal(Match{ResourceType: "FooType", Left: leftResources[1], Right: rightResources[1]}, matches[0])
+	m.Equal(Match{ResourceType: "FooType", Left: leftResources[3], Right: rightResources[3]}, matches[1])
 
 	m.Len(unmatchables, 4)
 	m.Equal([]interface{}{leftResources[0], leftResources[2], rightResources[0], rightResources[2]}, unmatchables)
@@ -283,7 +283,7 @@ func (m *MatcherTestSuite) TestMultipleMatchesOrderOfPreference() {
 
 	m.NoError(err)
 	m.Len(matches, 1)
-	m.Equal(Match{Left: leftResources[1], Right: rightResources[1]}, matches[0])
+	m.Equal(Match{ResourceType: "FooType", Left: leftResources[1], Right: rightResources[1]}, matches[0])
 
 	m.Len(unmatchables, 3)
 	m.Equal([]interface{}{leftResources[0], rightResources[0], rightResources[2]}, unmatchables)

--- a/merge/merge_types.go
+++ b/merge/merge_types.go
@@ -1,0 +1,83 @@
+package merge
+
+import (
+	"reflect"
+	"strings"
+)
+
+// Match pairs up to FHIR resources that "match". These resources should be of the same
+// resource type (e.g. Patient).
+type Match struct {
+	ResourceType string
+	Left         interface{}
+	Right        interface{}
+}
+
+// ResourceMap is used to map a list of resources to their specific type.
+type ResourceMap map[string][]interface{}
+
+func (r ResourceMap) Keys() []string {
+	keys := make([]string, len(r))
+	i := 0
+	for k := range r {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
+// PathMap captures all non-nil paths in a resource and the values at those paths.
+type PathMap map[string]reflect.Value
+
+func (p PathMap) Keys() []string {
+	keys := make([]string, len(p))
+	i := 0
+	for k := range p {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
+func getResourceType(resource interface{}) string {
+	// For example, "*models.Patient"
+	typeWithPackage := reflect.TypeOf(resource).String()
+	// So split that part out.
+	parts := strings.Split(typeWithPackage, ".")
+	if len(parts) != 2 {
+		return ""
+	}
+	return parts[1]
+}
+
+// intersection returns all elements in left that are also in right.
+func intersection(left, right []string) []string {
+	both := []string{}
+	for _, el := range left {
+		if contains(right, el) {
+			both = append(both, el)
+		}
+	}
+	return both
+}
+
+// setDiff returns all elements in left that are NOT in right.
+func setDiff(left, right []string) []string {
+	diffs := []string{}
+	for _, el := range left {
+		if !contains(right, el) {
+			diffs = append(diffs, el)
+		}
+	}
+	return diffs
+}
+
+// contains tests if an element is in the set.
+func contains(set []string, el string) bool {
+	for _, item := range set {
+		if item == el {
+			return true
+		}
+	}
+	return false
+}

--- a/merge/merge_types_test.go
+++ b/merge/merge_types_test.go
@@ -1,0 +1,76 @@
+package merge
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/mitre/ptmerge/testutil"
+	"github.com/stretchr/testify/suite"
+)
+
+type MergeTypesTestSuite struct {
+	suite.Suite
+}
+
+func TestMergeTypesTestSuite(t *testing.T) {
+	suite.Run(t, new(MergeTypesTestSuite))
+}
+
+func (m *MergeTypesTestSuite) TestGetResourceType() {
+	test, err := testutil.LoadFixture("Patient", "../fixtures/patients/foo_bar.json")
+	m.NoError(err)
+	typeAsString := getResourceType(test)
+	m.Equal("Patient", typeAsString)
+}
+
+func (m *MergeTypesTestSuite) TestResourceMapKeys() {
+	rm := make(ResourceMap)
+	rm["foo"] = []interface{}{1}
+	rm["bar"] = []interface{}{1, 2}
+	rm["hey"] = []interface{}{1, 2, 3}
+
+	expected := []string{"foo", "bar", "hey"} // Not necessarily in this order
+	keys := rm.Keys()
+	for _, k := range keys {
+		m.True(contains(expected, k))
+	}
+}
+
+func (m *MergeTypesTestSuite) TestPathMapKeys() {
+	pm := make(PathMap)
+	pm["foo"] = reflect.ValueOf(uint32(1))
+	pm["bar"] = reflect.ValueOf("hello")
+	pm["baz"] = reflect.ValueOf(time.Now())
+
+	expected := []string{"foo", "bar", "baz"} // Not necessarily in this order
+	keys := pm.Keys()
+	for _, k := range keys {
+		m.True(contains(expected, k))
+	}
+}
+
+func (m *MergeTypesTestSuite) TestSetIntersection() {
+	left := []string{"a", "b", "c"}
+	right := []string{"b", "c", "d"}
+
+	ints := intersection(left, right)
+	m.Equal([]string{"b", "c"}, ints)
+}
+
+func (m *MergeTypesTestSuite) TestSetDiff() {
+	left := []string{"a", "b", "c"}
+	right := []string{"b", "c", "d"}
+
+	lDiffs := setDiff(left, right)
+	m.Equal([]string{"a"}, lDiffs)
+
+	rDiffs := setDiff(right, left)
+	m.Equal([]string{"d"}, rDiffs)
+}
+
+func (m *MergeTypesTestSuite) TestSetContains() {
+	set := []string{"a", "b", "c"}
+	m.True(contains(set, "b"))
+	m.False(contains(set, "d"))
+}

--- a/merge/resource_traversal.go
+++ b/merge/resource_traversal.go
@@ -1,0 +1,112 @@
+package merge
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+)
+
+// traverse recursively iterates through all non-nil fields in a resource, identifying the JSON paths
+// to non-nil fields. Each path and the value at that path (a primitive go type, or a time.Time object)
+// is collected in the PathMap for later reference or comparison. To build a path, each exported field in
+// a resource must have a "json" struct tag. In practice this is true of all intervention-engine/fhir models.
+func traverse(value reflect.Value, paths PathMap, path string) {
+	switch value.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		// To get the actual value of the object or interface being pointed to we use Elem().
+		val := value.Elem()
+		// Check if the pointer or interface is nil.
+		if !val.IsValid() {
+			return
+		}
+		// Traverse the object that's being pointed to.
+		traverse(val, paths, path)
+
+	case reflect.Struct:
+		// We don't traverse into time objects.
+		if value.Type().Name() == "Time" {
+			paths[path] = value
+		}
+
+		// Traverse all non-nil fields in the struct, building up their json paths.
+		for i := 0; i < value.NumField(); i++ {
+			jsonPath := value.Type().Field(i).Tag.Get("json")
+			// jsonPath will be empty for inline resourced (e.g. DomainResource).
+			if jsonPath != "" {
+				prefix := ""
+				// The path is empty if we're currently traversing the top-level object (e.g. Patient).
+				if path != "" {
+					prefix = path + "."
+				}
+				// Splits into the name of the field (e.g. "gender") and the "omitempty" flag.
+				parts := strings.SplitN(jsonPath, ",", 2)
+				traverse(value.Field(i), paths, prefix+parts[0])
+			} else {
+				// This was an inline resource, so we shouldn't add it to the path. Just traverse
+				// it's fields instead.
+				traverse(value.Field(i), paths, path)
+			}
+		}
+
+	case reflect.Slice:
+		// Traverse all elements in the slice.
+		fmt.Println(value)
+		for i := 0; i < value.Len(); i++ {
+			traverse(value.Index(i), paths, path+fmt.Sprintf("[%d]", i))
+		}
+
+	case reflect.String:
+		// Check that the string isn't nil.
+		val := value.String()
+		if val != "" {
+			paths[path] = value
+		}
+
+	default:
+		// These are all of the other primitive types (e.g. int, float, bool).
+		paths[path] = value
+	}
+}
+
+// compareValues compares 2 reflected values obtained by traversing FHIR resources. The values
+// must be of the same kind to do a comparison. compareValues should only be used to compare values
+// collected by traverse(). Traverse ensures that only primitive go types (strings, bools, ints, etc.)
+// are collected as valid paths for comparison.
+func compareValues(left, right reflect.Value) bool {
+	if left.Kind() != right.Kind() {
+		return false
+	}
+
+	switch left.Kind() {
+	case reflect.String:
+		return left.String() == right.String()
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return left.Uint() == right.Uint()
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return left.Int() == right.Int()
+
+	case reflect.Float32, reflect.Float64:
+		return left.Float() == right.Float()
+
+	case reflect.Bool:
+		return left.Bool() == right.Bool()
+
+	// This is only for time.Time objects, all other structs should have been traversed.
+	case reflect.Struct:
+		leftTime, ok := left.Interface().(time.Time)
+		if !ok {
+			return false
+		}
+		rightTime, ok := right.Interface().(time.Time)
+		if !ok {
+			return false
+		}
+		return leftTime.Equal(rightTime)
+
+	default:
+		return false
+	}
+}

--- a/merge/resource_traversal_test.go
+++ b/merge/resource_traversal_test.go
@@ -1,0 +1,161 @@
+package merge
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/intervention-engine/fhir/models"
+	"github.com/stretchr/testify/suite"
+)
+
+type ResourceTraversalTestSuite struct {
+	suite.Suite
+}
+
+func TestResourceTraversalTestSuite(t *testing.T) {
+	suite.Run(t, new(ResourceTraversalTestSuite))
+}
+
+// ========================================================================= //
+// TEST STRUCT TRAVERSAL                                                     //
+// ========================================================================= //
+
+func (rt *ResourceTraversalTestSuite) TestStructTraversal() {
+	deceased := false
+	// Zero value pointers and strings are ignored, but zero numeric values should
+	// be preserved. The three major "zero" types are covered in this example:
+	// 1. nil pointers
+	// 2. empty strings
+	// 3. numeric values of 0
+	patient := &models.Patient{
+		Name: []models.HumanName{
+			models.HumanName{
+				Family: "Mercury",
+				Given:  []string{"Freddy"},
+			},
+		},
+		Gender:          "Male",
+		DeceasedBoolean: &deceased,
+		MaritalStatus: &models.CodeableConcept{
+			Coding: []models.Coding{
+				models.Coding{
+					System:  "http://hl7.org/fhir/v3/MaritalStatus",
+					Code:    "M",
+					Display: "Married",
+				},
+			},
+		},
+		Address: []models.Address{
+			models.Address{
+				Line:    []string{"1 London Way"},
+				City:    "London",
+				Country: "UK",
+			},
+		},
+		BirthDate: &models.FHIRDateTime{
+			// We don't traverse into time objects, so there will only be one path here.
+			Time: time.Now().UTC(),
+		},
+	}
+
+	// Adding a contained quantity object to test the handling of zero-value numeric types.
+	quantity := float64(0)
+	patient.Contained = []interface{}{
+		models.Quantity{
+			Value: &quantity,
+			Unit:  "Songs",
+		},
+	}
+
+	// The order is deterministic. We expect these fields to be non-nil
+	// in the JSON equivalent of this patient object.
+	expected := []string{
+		"contained[0].value",
+		"contained[0].unit",
+		"name[0].family",
+		"name[0].given[0]",
+		"gender",
+		"birthDate",
+		"deceasedBoolean",
+		"address[0].line[0]",
+		"address[0].city",
+		"address[0].country",
+		"maritalStatus.coding[0].system",
+		"maritalStatus.coding[0].code",
+		"maritalStatus.coding[0].display",
+	}
+	value := reflect.ValueOf(*patient)
+	pathmap := make(PathMap)
+	traverse(value, pathmap, "")
+
+	spew.Dump(pathmap.Keys())
+
+	// The order of the keys is not deterministic, so we need to use contains().
+	for _, k := range pathmap.Keys() {
+		rt.True(contains(expected, k))
+	}
+}
+
+// ========================================================================= //
+// TEST REFLECTION VALUE COMPARISON                                          //
+// ========================================================================= //
+
+func (rt *ResourceTraversalTestSuite) TestCompareStringValues() {
+	v1 := reflect.ValueOf("hello")
+	v2 := reflect.ValueOf("hello")
+	rt.True(compareValues(v1, v2))
+
+	v3 := reflect.ValueOf("world")
+	rt.False(compareValues(v1, v3))
+}
+
+func (rt *ResourceTraversalTestSuite) TestCompareIntegerValues() {
+	i1 := reflect.ValueOf(uint32(2))
+	i2 := reflect.ValueOf(uint32(2))
+	rt.True(compareValues(i1, i2))
+
+	i3 := reflect.ValueOf(uint32(0))
+	rt.False(compareValues(i1, i3))
+
+	i4 := reflect.ValueOf(uint32(0))
+	rt.True(compareValues(i3, i4))
+}
+
+func (rt *ResourceTraversalTestSuite) TestCompareFloatValues() {
+	i1 := reflect.ValueOf(float64(5.2))
+	i2 := reflect.ValueOf(float64(5.2))
+	rt.True(compareValues(i1, i2))
+
+	i3 := reflect.ValueOf(float64(0))
+	rt.False(compareValues(i1, i3))
+
+	i4 := reflect.ValueOf(float64(0))
+	rt.True(compareValues(i3, i4))
+}
+
+func (rt *ResourceTraversalTestSuite) TestCompareBooleanValues() {
+	v1 := reflect.ValueOf(false)
+	v2 := reflect.ValueOf(false)
+	rt.True(compareValues(v1, v2))
+
+	v3 := reflect.ValueOf(true)
+	rt.False(compareValues(v1, v3))
+}
+
+func (rt *ResourceTraversalTestSuite) TestCompareTimeValues() {
+	t := time.Now().UTC()
+	t1 := reflect.ValueOf(t)
+	t2 := reflect.ValueOf(t)
+	rt.True(compareValues(t1, t2))
+
+	t3 := reflect.ValueOf(time.Now().UTC())
+	rt.False(compareValues(t1, t3))
+}
+
+func (rt *ResourceTraversalTestSuite) TestCompareDifferentKindsAlwaysFalse() {
+	v1 := reflect.ValueOf("foo")
+	v2 := reflect.ValueOf(3)
+	rt.False(compareValues(v1, v2))
+}


### PR DESCRIPTION
I implemented a generic conflict detection framework that works for **any resource type**.

Using reflection, all fields in a resource are recursively traversed until a primitive golang type (int, bool, float, etc.) or a time.Time object is reached. These primitive types are then compared to determine conflicts.

Fields found only in one resource (left or right) are automatically marked as a conflict.

My gut tells me we'll need to add more detail to an OperationOutcome describing a conflict. At present there's nothing clearly linking the conflicts in an OperationOutcome to a specific trio of `[left, right, target]` resources.