### PR TITLE
New Target Resource Routes

### DIFF
--- a/fhirutil/resource_utilities.go
+++ b/fhirutil/resource_utilities.go
@@ -31,6 +31,22 @@ func GetResourceType(resource interface{}) string {
 	return ""
 }
 
+// JSONGetResourceType gets the string equivalent of a FHIR resource type
+// from the map[string]interface{} equivalent of FHIR JSON for that resource.
+func JSONGetResourceType(obj []byte) string {
+	var resource map[string]interface{}
+	err := json.Unmarshal(obj, &resource)
+	if err != nil {
+		return ""
+	}
+
+	s, ok := resource["resourceType"].(string)
+	if !ok {
+		return ""
+	}
+	return s
+}
+
 // GetResourceByURL GETs a FHIR resource from it's specified URL.
 func GetResourceByURL(resourceType, resourceURL string) (resource interface{}, err error) {
 	// Make the request.
@@ -70,11 +86,11 @@ func GetResource(host, resourceType, resourceID string) (resource interface{}, e
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode == 404 {
+	if res.StatusCode == http.StatusNotFound {
 		return nil, fmt.Errorf("Resource %s:%s not found", resourceType, resourceID)
 	}
 
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("An unexpected error occured while requesting resource %s:%s", resourceType, resourceID)
 	}
 

--- a/fhirutil/resource_utilities.go
+++ b/fhirutil/resource_utilities.go
@@ -32,7 +32,7 @@ func GetResourceType(resource interface{}) string {
 }
 
 // JSONGetResourceType gets the string equivalent of a FHIR resource type
-// from the map[string]interface{} equivalent of FHIR JSON for that resource.
+// from the JSON byte string of that resource.
 func JSONGetResourceType(obj []byte) string {
 	var resource map[string]interface{}
 	err := json.Unmarshal(obj, &resource)

--- a/fixtures/bundles/lowell_abbott_unmarried_bundle.json
+++ b/fixtures/bundles/lowell_abbott_unmarried_bundle.json
@@ -137,7 +137,7 @@
                     "start": "2016-11-01"
                 }
             }
-				},
+		},
         {
             "resource": {
                 "resourceType": "Procedure",

--- a/fixtures/medication_statements/medication_statement_1.json
+++ b/fixtures/medication_statements/medication_statement_1.json
@@ -1,0 +1,20 @@
+{
+    "resourceType": "MedicationStatement",
+    "id": "58a4904e97bba945de21fac0",
+    "status": "active",
+    "medicationCodeableConcept": {
+        "coding": [
+            {
+                "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                "code": "860975",
+                "display": "24 HR Metformin hydrochloride 500 MG Extended Release Oral Tablet"
+            }
+        ]
+    },
+    "subject": {
+        "reference": "Patient/58a4904e97bba945de21eac8"
+    },
+    "effectivePeriod": {
+        "start": "2016-11-01"
+    }
+}

--- a/server/routing.go
+++ b/server/routing.go
@@ -10,15 +10,22 @@ func RegisterRoutes(router *gin.Engine, session *mgo.Session, dbname string, fhi
 
 	mc := NewMergeController(session, dbname, fhirHost)
 
-	// Merging and confict resolution.
+	// Merge operations.
 	router.POST("/merge", mc.Merge)
 	router.POST("/merge/:merge_id/resolve/:conflict_id", mc.Resolve)
 	router.POST("/merge/:merge_id/abort", mc.DeleteMerge)
 
-	// Convenience routes.
-	router.GET("/merge", mc.AllMerges)
-	router.GET("/merge/:merge_id", mc.GetMerge)
+	// Merge target management.
+	router.GET("/merge/:merge_id/target", mc.GetTarget)
+	router.POST("/merge/:merge_id/target/resources/:resource_id", mc.UpdateTargetResource)
+	router.DELETE("/merge/:merge_id/target/resources/:resource_id", mc.DeleteTargetResource)
+
+	// Merge conflict management.
 	router.GET("/merge/:merge_id/conflicts", mc.GetRemainingConflicts)
 	router.GET("/merge/:merge_id/resolved", mc.GetResolvedConflicts)
-	router.GET("/merge/:merge_id/target", mc.GetTarget)
+	router.DELETE("/merge/:merge_id/conflicts/:conflict_id", mc.DeleteConflict)
+
+	// Merge metadata.
+	router.GET("/merge", mc.AllMerges)
+	router.GET("/merge/:merge_id", mc.GetMerge)
 }


### PR DESCRIPTION
Added routes to update and delete an unmatched target resource. Also added the ability to delete a merge conflict and its related resources. New routes:

### Update Target Resource:
```
POST /merge/:merge_id/target/resources/:resource_id
```

### Delete Target Resource:
```
DELETE /merge/:merge_id/target/resources/:resource_id
```

### Delete a Conflict (and It's Target Resource):
```
DELETE /merge/:merge_id/conflicts/:conflict_id
```