### PR TITLE
Final Updates

### DIFF
--- a/fixtures/bundles/dup_patient_bundle.json
+++ b/fixtures/bundles/dup_patient_bundle.json
@@ -1,0 +1,181 @@
+{
+    "resourceType": "Bundle",
+    "type": "collection",
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "Patient",
+                "id": "58a4904e97bba945de21eac8",
+                "name": [
+                    {
+                        "given": ["Joseph"],
+                        "family": "Chestnut"
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1977-01-06",
+                "maritalStatus": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/v3/MaritalStatus",
+                            "code": "D",
+                            "display": "Divorced"
+                        }
+                    ]
+                },
+                "address": [
+                    {
+                        "use": "home",
+                        "line": ["300 Centurion Blvd"],
+                        "city": "Los Alamos",
+                        "state": "TX",
+                        "postal": "76453"
+                    }
+                ],
+                "telecom": [
+                    {
+                        "system": "phone",
+                        "value": "406.531.9696",
+                        "use": "home"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Patient",
+                "id": "58a4904e97bba945de21ebc8",
+                "name": [
+                    {
+                        "given": ["Joey"],
+                        "family": "Chestnut"
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1977-01-06",
+                "maritalStatus": {
+                    "coding": [
+                        {
+                            "system": "http://hl7.org/fhir/v3/MaritalStatus",
+                            "code": "M",
+                            "display": "Married"
+                        }
+                    ]
+                },
+                "address": [
+                    {
+                        "use": "home",
+                        "line": ["300 Centurion Blvd"],
+                        "city": "Los Alamos",
+                        "state": "TX",
+                        "postal": "76453"
+                    }
+                ],
+                "telecom": [
+                    {
+                        "system": "phone",
+                        "value": "406.531.9696",
+                        "use": "home"
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Condition",
+                "id": "58a4904e07bca945de21eac8",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "195967001",
+                            "display": "Asthma"
+                        }
+                    ]
+                },
+                "onsetDateTime": "2000-05-21",
+                "subject": {
+                    "reference": "Patient/58a4904e97bba945de21eac8"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Encounter",
+                "id": "58a4904e97bba945ee21eac8",
+                "status": "finished",
+                "period": {
+                    "start": "2016-04-13",
+                    "end": "2016-04-13"
+                },
+                "class": {
+                    "code": "outpatient"
+                },
+                "type": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "185349003",
+                                "display": "Encounter for problem"
+                            }
+                        ]
+                    }
+                ],
+                "patient": {
+                    "reference": "Patient/58a4904e97bba945de21eac8"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Encounter",
+                "id": "58a4904e97bba945de21eac0",
+                "status": "finished",
+                "period": {
+                    "start": "2014-08-03",
+                    "end": "2014-08-03"
+                },
+                "class": {
+                    "code": "outpatient"
+                },
+                "type": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "185349003",
+                                "display": "Encounter for problem"
+                            }
+                        ]
+                    }
+                ],
+                "patient": {
+                    "reference": "Patient/58a4904e97bba945de21eac8"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "58a4904e97bba945de21fac0",
+                "status": "active",
+                "medicationCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                            "code": "895994",
+                            "display": "120 ACTUAT Fluticasone propionate 0.044 MG/ACTUAT Metered Dose Inhaler"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/58a4904e97bba945de21eac8"
+                },
+                "effectivePeriod": {
+                    "start": "2000-05-21"
+                }
+            }
+        }
+    ]
+}

--- a/fixtures/bundles/no_patient_bundle.json
+++ b/fixtures/bundles/no_patient_bundle.json
@@ -1,0 +1,103 @@
+{
+    "resourceType": "Bundle",
+    "type": "collection",
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "Condition",
+                "id": "58a4904e07bca945de21eac8",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "195967001",
+                            "display": "Asthma"
+                        }
+                    ]
+                },
+                "onsetDateTime": "2000-05-21",
+                "subject": {
+                    "reference": "Patient/58a4904e97bba945de21eac8"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Encounter",
+                "id": "58a4904e97bba945ee21eac8",
+                "status": "finished",
+                "period": {
+                    "start": "2016-04-13",
+                    "end": "2016-04-13"
+                },
+                "class": {
+                    "code": "outpatient"
+                },
+                "type": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "185349003",
+                                "display": "Encounter for problem"
+                            }
+                        ]
+                    }
+                ],
+                "patient": {
+                    "reference": "Patient/58a4904e97bba945de21eac8"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Encounter",
+                "id": "58a4904e97bba945de21eac0",
+                "status": "finished",
+                "period": {
+                    "start": "2014-08-03",
+                    "end": "2014-08-03"
+                },
+                "class": {
+                    "code": "outpatient"
+                },
+                "type": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "185349003",
+                                "display": "Encounter for problem"
+                            }
+                        ]
+                    }
+                ],
+                "patient": {
+                    "reference": "Patient/58a4904e97bba945de21eac8"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "MedicationStatement",
+                "id": "58a4904e97bba945de21fac0",
+                "status": "active",
+                "medicationCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                            "code": "895994",
+                            "display": "120 ACTUAT Fluticasone propionate 0.044 MG/ACTUAT Metered Dose Inhaler"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/58a4904e97bba945de21eac8"
+                },
+                "effectivePeriod": {
+                    "start": "2000-05-21"
+                }
+            }
+        }
+    ]
+}

--- a/merge/matcher.go
+++ b/merge/matcher.go
@@ -24,9 +24,13 @@ var (
 	// match for the whole resource to be considered a match.
 	MatchThreshold = 0.8
 
-	// ErrNoPatientMatch indicates that the patient resources in the bundles didn't exist or didn't match.
-	// A merge cannot continue if there aren't minimally matching patients.
-	ErrNoPatientMatch = errors.New("Patient resources do not match")
+	// ErrNoPatientResource occurs if a Patient resource is not found in one or both
+	// source bundles.
+	ErrNoPatientResource = errors.New("Patient resource not found in one or both source bundles")
+
+	// ErrDuplicatePatientResource occurs if more than one Patient resource is found
+	// in either source bundle.
+	ErrDuplicatePatientResource = errors.New("Duplicate Patient resources found in one or both source bundles")
 )
 
 // Matcher provides tools for identifying all resources in 2 source bundles that "match".
@@ -59,7 +63,7 @@ func (m *Matcher) Match(leftBundle, rightBundle *models.Bundle) (matches []Match
 	// If the Patient resource is not in matchableResourceTypes, return an error.
 	// Minimally we need a single, matching Patient object to perform a merge.
 	if !contains(matchableResourceTypes, "Patient") {
-		return nil, nil, errors.New("Patient resource not found in one or both bundles")
+		return nil, nil, ErrNoPatientResource
 	}
 
 	// Handle all of the unmatchable resource types.
@@ -78,16 +82,28 @@ func (m *Matcher) Match(leftBundle, rightBundle *models.Bundle) (matches []Match
 		lefts := leftResources[resourceType]
 		rights := rightResources[resourceType]
 
-		// Performs matching without replacement, always comparing the next available left
-		// to the remaining rights.
+		// Always match the patient resource, even if there are many conflicts.
+		// This allows bundles that are seemingly dissimilar to be merged.
+		if resourceType == "Patient" {
+			if len(lefts) > 1 || len(rights) > 1 {
+				// Cannot handle duplicate Patient resources.
+				return nil, nil, ErrDuplicatePatientResource
+			}
+
+			// Create a match for the Patient resources.
+			matches = append(matches, Match{
+				ResourceType: "Patient",
+				Left:         lefts[0],
+				Right:        rights[0],
+			})
+			continue
+		}
+
+		// For all other resource types, perform matching without replacement.
+		// This  always comparing the next available left to the remaining rights.
 		someMatches, someUnmatchables, err := m.matchWithoutReplacement(lefts, rights)
 		if err != nil {
 			return nil, nil, err
-		}
-
-		if resourceType == "Patient" && len(someMatches) == 0 {
-			// There was no matching Patient resource.
-			return nil, nil, ErrNoPatientMatch
 		}
 
 		matches = append(matches, someMatches...)

--- a/merge/matcher.go
+++ b/merge/matcher.go
@@ -100,7 +100,7 @@ func (m *Matcher) Match(leftBundle, rightBundle *models.Bundle) (matches []Match
 		}
 
 		// For all other resource types, perform matching without replacement.
-		// This  always comparing the next available left to the remaining rights.
+		// This always compares the next available left to the remaining rights.
 		someMatches, someUnmatchables, err := m.matchWithoutReplacement(lefts, rights)
 		if err != nil {
 			return nil, nil, err

--- a/ptmerge.go
+++ b/ptmerge.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	// command line flags
 	fhirhost := flag.String("fhirhost", "http://localhost:3001", "The FHIR server used to host the ptmerge service")
-	dbhost := flag.String("db", "localhost:27017", "The Mongo database used to host the ptmerge service")
+	dbhost := flag.String("dbhost", "localhost:27017", "The Mongo database used to host the ptmerge service")
 	dbname := flag.String("dbname", "ptmerge", "The name of the Mongo database")
 	debug := flag.Bool("debug", false, "Run the ptmerge service in debug mode (more verbose output)")
 	flag.Parse()

--- a/server/merge_controller.go
+++ b/server/merge_controller.go
@@ -100,11 +100,15 @@ func (m *MergeController) Merge(c *gin.Context) {
 
 	// Some conflicts exist, create a new record in mongo to manage this merge's state.
 	mergeID := bson.NewObjectId().Hex()
+	now := time.Now()
 	err = worker.DB(m.dbname).C("merges").Insert(&state.MergeState{
-		MergeID:   mergeID,
-		Completed: false,
-		TargetURL: targetURL,
-		Conflicts: conflictMap,
+		MergeID:    mergeID,
+		Completed:  false,
+		Source1URL: source1,
+		Source2URL: source2,
+		TargetURL:  targetURL,
+		Conflicts:  conflictMap,
+		Start:      &now,
 	})
 
 	if err != nil {
@@ -197,7 +201,10 @@ func (m *MergeController) Resolve(c *gin.Context) {
 	numRemaining := len(mergeState.Conflicts.RemainingConflicts())
 	if numRemaining == 0 {
 		// No conflicts remaining, mark the merge as "completed" and return the target Bundle.
-		err = worker.DB(m.dbname).C("merges").UpdateId(mergeID, bson.M{"$set": bson.M{"completed": true}})
+		mergeState.Completed = true
+		now := time.Now()
+		mergeState.End = &now
+		err = worker.DB(m.dbname).C("merges").UpdateId(mergeID, bson.M{"$set": mergeState})
 		if err != nil {
 			c.String(http.StatusInternalServerError, err.Error())
 			return

--- a/server/merge_controller.go
+++ b/server/merge_controller.go
@@ -55,7 +55,7 @@ func (m *MergeController) Merge(c *gin.Context) {
 	outcome, targetURL, err := merger.Merge(source1, source2)
 
 	if err != nil {
-		if err == merge.ErrNoPatientMatch {
+		if err == merge.ErrNoPatientResource || err == merge.ErrDuplicatePatientResource {
 			c.String(http.StatusBadRequest, err.Error())
 			return
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -269,8 +269,12 @@ func (s *ServerTestSuite) TestMergeSomeConflicts() {
 
 	// Validate the mergeState.
 	s.Equal(mergeID, mergeState.MergeID)
+	s.Equal(source1, mergeState.Source1URL)
+	s.Equal(source2, mergeState.Source2URL)
 	s.Equal(s.FHIRServer.URL+"/Bundle/"+targetBundle.Id, mergeState.TargetURL)
 	s.False(mergeState.Completed)
+	s.NotNil(mergeState.Start)
+	s.Nil(mergeState.End)
 	s.Len(mergeState.Conflicts, 2)
 
 	// Patient conflict metadata.
@@ -625,8 +629,12 @@ func (s *ServerTestSuite) TestResolveConflictNoMoreConflicts() {
 
 	// Validate the mergeState.
 	s.Equal(mergeID, mergeState.MergeID)
+	s.Equal(source1, mergeState.Source1URL)
+	s.Equal(source2, mergeState.Source2URL)
 	s.Equal(s.FHIRServer.URL+"/Bundle/"+targetBundle.Id, mergeState.TargetURL)
 	s.True(mergeState.Completed)
+	s.NotNil(mergeState.Start)
+	s.NotNil(mergeState.End)
 	s.Len(mergeState.Conflicts, 2)
 
 	// The patient conflict should now be resolved.

--- a/state/state.go
+++ b/state/state.go
@@ -17,10 +17,14 @@ type Merge struct {
 // MergeState represents the current state of a merge as it is stored in mongo.
 // This is stored in the "merges" collection.
 type MergeState struct {
-	MergeID   string      `bson:"_id,omitempty" json:"id,omitempty"`
-	TargetURL string      `bson:"targetBundle,omitempty" json:"targetBundle,omitempty"`
-	Conflicts ConflictMap `bson:"conflicts,omitempty" json:"conflicts,omitempty"`
-	Completed bool        `bson:"completed" json:"completed"`
+	MergeID    string      `bson:"_id,omitempty" json:"id,omitempty"`
+	Source1URL string      `bson:"source1,omitempty" json:"source1,omitempty"`
+	Source2URL string      `bson:"source2,omitempty" json:"source2,omitempty"`
+	TargetURL  string      `bson:"targetBundle,omitempty" json:"targetBundle,omitempty"`
+	Conflicts  ConflictMap `bson:"conflicts,omitempty" json:"conflicts,omitempty"`
+	Completed  bool        `bson:"completed" json:"completed"`
+	Start      *time.Time  `bson:"start,omitempty" json:"start,omitempty"`
+	End        *time.Time  `bson:"end,omitempty" json:"end,omitempty"`
 }
 
 // ConflictMap is a map containing one or more ConflictStates. The key to each


### PR DESCRIPTION
There are 2 distinct updates in this PR, one commit for each:

1. Patient resources now always "match" (although there may be many conflicts). This allows users to merge seemingly dissimilar bundles, as long as each bundle has one and only one patient resource in it.

2. We now capture additional metadata for a merge, including:
a. URLs to both source bundles
b. A `start` and `end` timestamp for each merge